### PR TITLE
CodeCargo: update actions/checkout to v6.0.2

### DIFF
--- a/.github/workflows/bpf-generate.yml
+++ b/.github/workflows/bpf-generate.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: code-cargo/cargowall-action@v1.0.1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: code-cargo/cargowall-action@v1.0.1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-go@v6
         with:
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: code-cargo/cargowall-action@v1.0.1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-go@v6
         with:
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: code-cargo/cargowall-action@v1.0.1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-go@v6
         with:
@@ -129,7 +129,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download binary
         uses: actions/download-artifact@v8
@@ -276,7 +276,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download binary
         uses: actions/download-artifact@v8
@@ -308,7 +308,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download binary
         uses: actions/download-artifact@v8
@@ -515,7 +515,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download binary
         uses: actions/download-artifact@v8
@@ -676,7 +676,7 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download binary
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: code-cargo/cargowall-action@v1.0.1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
 


### PR DESCRIPTION
## Update actions/checkout

Updates all references to `actions/checkout` to version `v6.0.2`.

> SHA-pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)

### Modified workflows
- `.github/workflows/ci.yml`
- `.github/workflows/bpf-generate.yml`
- `.github/workflows/release.yml`

---
Generated by [CodeCargo](https://codecargo.com)