### PR TITLE
CodeCargo: update actions/cache to v5.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Cache Go tools
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/bin
           key: go-tools-${{ hashFiles('Makefile') }}


### PR DESCRIPTION
## Update actions/cache

Updates all references to `actions/cache` to version `v5.0.5`.

> SHA-pinned to `27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5)

### Modified workflows
- `.github/workflows/ci.yml`

---
Generated by [CodeCargo](https://codecargo.com)