### PR TITLE
CodeCargo: update code-cargo/cargowall-action to v1.2.0

### DIFF
--- a/.github/workflows/bpf-generate.yml
+++ b/.github/workflows/bpf-generate.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@v1.1.1
+      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@v1.1.1
+      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -56,7 +56,7 @@ jobs:
       id-token: write
       checks: write
     steps:
-      - uses: code-cargo/cargowall-action@v1.1.1
+      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -95,7 +95,7 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@v1.1.1
+      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -141,7 +141,7 @@ jobs:
         run: chmod +x bin/cargowall
 
       - name: Start CargoWall via Action
-        uses: code-cargo/cargowall-action@v1.1.1
+        uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
         with:
           mode: enforce
           offline: 'true'
@@ -288,7 +288,7 @@ jobs:
         run: chmod +x bin/cargowall
 
       - name: Start CargoWall via Action
-        uses: code-cargo/cargowall-action@v1.1.1
+        uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
         with:
           mode: audit
           offline: 'true'
@@ -687,6 +687,6 @@ jobs:
       - name: Make binary executable
         run: chmod +x bin/cargowall
 
-      - uses: code-cargo/cargowall-action@main
+      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
         with:
           binary-path: ./bin/cargowall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     steps:
-      - uses: code-cargo/cargowall-action@v1.1.1
+      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -70,7 +70,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: code-cargo/cargowall-action@v1.1.1
+      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
 
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Update code-cargo/cargowall-action

Updates all references to `code-cargo/cargowall-action` to version `v1.2.0`.

> SHA-pinned to `fc9644606d84536b4e59a30ad2802904f7b4ff22` (v1.2.0)

### Modified workflows
- `.github/workflows/bpf-generate.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

---
Generated by [CodeCargo](https://codecargo.com)