### PR TITLE
Add GitLab CI Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,6 +667,126 @@ jobs:
           fi
           echo "Emergency cleanup complete"
 
+  test-cargowall-gitlab-ci:
+    name: Integration Test (GitLab CI mode)
+    needs: build-binary
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download binary
+        uses: actions/download-artifact@v8
+        with:
+          name: cargowall-binary
+          path: bin
+
+      - name: Make binary executable
+        run: chmod +x bin/cargowall
+
+      - name: Write minimal policy
+        run: |
+          sudo mkdir -p /etc/cargowall
+          sudo tee /etc/cargowall/config.json > /dev/null <<'JSON'
+          {
+            "defaultAction": "deny",
+            "rules": [
+              {
+                "type": "hostname",
+                "value": "github.com",
+                "ports": [{"port": 443, "protocol": "tcp"}],
+                "action": "allow"
+              },
+              {
+                "type": "cidr",
+                "value": "8.8.8.8/32",
+                "ports": [{"port": 53, "protocol": "udp"}],
+                "action": "allow"
+              }
+            ]
+          }
+          JSON
+
+      - name: Start CargoWall with --gitlab-ci preset
+        run: |
+          # nohup + & + disown lets cargowall outlive this step's shell.
+          # The privileged-Docker stand-in for GitLab SaaS doesn't exist on
+          # GitHub Actions runners, so we exercise the same code path on the
+          # Azure-backed Linux runner — eBPF + sudo + iptables work the same.
+          sudo nohup ./bin/cargowall start \
+            --gitlab-ci \
+            --audit-mode \
+            --audit-log /tmp/cargowall-audit.json \
+            --pidfile /tmp/cargowall.pid \
+            --dns-upstream "8.8.8.8:53" \
+            --debug \
+            > /tmp/cargowall.log 2>&1 &
+          disown
+
+      - name: Wait for ready via wait-ready subcommand
+        run: ./bin/cargowall wait-ready --timeout 30s
+
+      - name: Show startup log (debug aid)
+        if: always()
+        run: sudo cat /tmp/cargowall.log || true
+
+      - name: Verify pidfile written
+        run: |
+          if ! sudo test -s /tmp/cargowall.pid; then
+            echo "❌ pidfile /tmp/cargowall.pid was not written"
+            exit 1
+          fi
+          echo "✅ pidfile present, pid=$(sudo cat /tmp/cargowall.pid)"
+
+      - name: Allowed call reaches github.com
+        run: |
+          curl -sf --connect-timeout 10 --max-time 30 https://github.com > /dev/null
+          echo "✅ github.com reachable"
+
+      - name: Disallowed call still goes through (audit mode logs only)
+        run: |
+          curl -sf --connect-timeout 5 --max-time 10 https://example.com > /dev/null || true
+          echo "✅ example.com fetch attempted (audit mode does not block)"
+
+      - name: Validate audit log contains would-deny events
+        run: |
+          AUDIT_LOG=/tmp/cargowall-audit.json
+          if ! sudo test -s "$AUDIT_LOG"; then
+            echo "❌ Audit log not written"
+            exit 1
+          fi
+          BLOCKED=$(sudo jq -s '[.[] | select(.event_type == "connection_blocked" or .event_type == "dns_blocked")] | length' "$AUDIT_LOG")
+          echo "would-deny events: $BLOCKED"
+          if [ "$BLOCKED" -eq 0 ]; then
+            echo "❌ Expected at least one would-deny event in audit log"
+            sudo head -5 "$AUDIT_LOG" | jq .
+            exit 1
+          fi
+          echo "✅ Audit log contains $BLOCKED would-deny events"
+
+      - name: Stop CargoWall via stop subcommand
+        run: |
+          sudo ./bin/cargowall stop --pidfile /tmp/cargowall.pid --timeout 15s
+          echo "✅ stop subcommand returned cleanly"
+
+      - name: Verify pidfile removed
+        run: |
+          if sudo test -f /tmp/cargowall.pid; then
+            echo "❌ pidfile still present after stop"
+            sudo ls -la /tmp/cargowall.pid
+            exit 1
+          fi
+          echo "✅ pidfile cleaned up"
+
+      - name: Emergency cleanup
+        if: always()
+        run: |
+          if sudo test -f /tmp/cargowall.pid; then
+            sudo kill -TERM $(sudo cat /tmp/cargowall.pid) 2>/dev/null || true
+          fi
+
   test-cargowall-saas:
     name: Integration Test (SaaS)
     needs: build-binary

--- a/README.md
+++ b/README.md
@@ -197,11 +197,15 @@ sudo cargowall start \
   --dns-upstream 8.8.8.8:53
 ```
 
-Standalone mode does **not** install the iptables DNS redirect or rewrite Docker's DNS config — that wiring is only applied in GitHub Actions mode. You need to route DNS traffic through the local proxy yourself, otherwise hostname rules will never populate (e.g. the `github.com` allow rule above will stay empty and traffic will be blocked under a deny-by-default policy). Common options:
+By default, standalone mode does **not** install the iptables DNS redirect or rewrite Docker's DNS config. You need to route DNS traffic through the local proxy yourself, otherwise hostname rules will never populate (e.g. the `github.com` allow rule above will stay empty and traffic will be blocked under a deny-by-default policy). Three options:
 
-* Point `/etc/resolv.conf` at `nameserver 127.0.0.1` for host processes
-* Pass `--dns 127.0.0.1` to `docker run` (or set `"dns"` in `/etc/docker/daemon.json`) for containers
-* Add your own `iptables` NAT rule redirecting outbound `udp/tcp 53` to `127.0.0.1:53` for processes that bypass `/etc/resolv.conf` (Go's pure resolver, Node.js)
+1. **Pass the orthogonal flags** to let cargowall do the wiring (recommended on CI runners):
+   ```bash
+   sudo cargowall start --config /etc/cargowall/config.json --dns-upstream 8.8.8.8:53 \
+     --dns-redirect-iptables --docker-dns-interception --dns-query-filtering
+   ```
+2. **Use a CI preset** (`--github-action` or `--gitlab-ci`) — bundles all of the above plus cache pre-population and CI-specific host auto-allow.
+3. **Wire it manually**: point `/etc/resolv.conf` at `nameserver 127.0.0.1`, pass `--dns 127.0.0.1` to `docker run`, add your own `iptables -t nat -A OUTPUT -p udp --dport 53 ! -d 127.0.0.0/8 -j DNAT --to-destination 127.0.0.1:53`.
 
 Useful flags (most available as env vars — see `cargowall start --help`):
 
@@ -212,9 +216,59 @@ Useful flags (most available as env vars — see `cargowall start --help`):
 | `--dns-upstream` | `CARGOWALL_DNS_UPSTREAM` | Upstream DNS server (required) |
 | `--audit-mode` | `CARGOWALL_AUDIT_MODE` | Log only — don't block (recommended for rollout) |
 | `--audit-log` | `CARGOWALL_AUDIT_LOG` | NDJSON audit log path |
+| `--pidfile` | `CARGOWALL_PIDFILE` | Write the cargowall pid here so `cargowall stop` can target it |
 | `--debug` | — | Verbose logging |
+| `--github-action` | `CARGOWALL_GITHUB_ACTION` | GitHub Actions preset (expands the orthogonal flags below) |
+| `--gitlab-ci` | `CARGOWALL_GITLAB_CI` | GitLab CI preset (same plumbing, GitLab service host auto-allow instead) |
+| `--dns-redirect-iptables` | `CARGOWALL_DNS_REDIRECT_IPTABLES` | iptables DNAT outbound :53 → `127.0.0.1:53` |
+| `--docker-dns-interception` | `CARGOWALL_DOCKER_DNS_INTERCEPTION` | Listen on the Docker bridge IP and rewrite `/etc/docker/daemon.json` |
+| `--dns-query-filtering` | `CARGOWALL_DNS_QUERY_FILTERING` | Filter DNS queries against the policy (blocks DNS tunneling) |
+| `--prepopulate-dns-cache` | `CARGOWALL_PREPOPULATE_DNS_CACHE` | Seed the BPF allowlist from systemd-resolved + existing TCP connections |
+| `--auto-allow-cloud-metadata` | `CARGOWALL_AUTO_ALLOW_CLOUD_METADATA` | Allow Azure IMDS / GCP metadata at `169.254.169.254` (auto-detects Azure wireserver too) |
+| `--auto-allow-github-hosts` | `CARGOWALL_AUTO_ALLOW_GITHUB_HOSTS` | Allow GitHub service hosts + `ACTIONS_*` runtime URL discovery |
+| `--auto-allow-gitlab-hosts` | `CARGOWALL_AUTO_ALLOW_GITLAB_HOSTS` | Allow GitLab service hosts + `CI_*` runtime URL discovery |
 
-When CargoWall is ready, it writes a `/tmp/cargowall-ready` sentinel — useful for CI scripts that want to gate the build step until the firewall is up.
+When CargoWall is ready, it writes a `/tmp/cargowall-ready` sentinel. Use the `cargowall wait-ready` subcommand from your CI script to block until the firewall is up — it polls the sentinel and exits non-zero on timeout.
+
+## GitLab CI
+
+GitLab SaaS Linux runners give your job root inside a privileged Docker container, which is enough for eBPF — but you'll want to run a smoke job first to confirm `cargowall start --gitlab-ci` actually attaches in your project's runner image. Self-hosted runners with a recent kernel are the well-trodden path.
+
+```yaml
+variables:
+  CARGOWALL_VERSION: v1.2.0
+
+build:
+  tags: [self-hosted-linux]   # or remove for SaaS shared runners (see caveats above)
+  before_script:
+    - curl -fsSL -o /usr/local/bin/cargowall https://github.com/code-cargo/cargowall/releases/download/${CARGOWALL_VERSION}/cargowall-linux-amd64
+    - chmod +x /usr/local/bin/cargowall
+    - mkdir -p /etc/cargowall
+    - |
+      cat > /etc/cargowall/config.json <<'EOF'
+      {
+        "defaultAction": "deny",
+        "rules": [
+          {"type":"hostname","value":"gitlab.com","ports":[{"port":443,"protocol":"tcp"}],"action":"allow"},
+          {"type":"hostname","value":"registry.npmjs.org","ports":[{"port":443,"protocol":"tcp"}],"action":"allow"},
+          {"type":"cidr","value":"8.8.8.8/32","ports":[{"port":53,"protocol":"udp"}],"action":"allow"}
+        ]
+      }
+      EOF
+    - cargowall start --gitlab-ci --audit-mode --audit-log /tmp/cargowall.ndjson --pidfile /tmp/cargowall.pid --dns-upstream 8.8.8.8:53 &
+    - cargowall wait-ready --timeout 30s
+  script:
+    - npm ci
+    - npm run build
+  after_script:
+    - cargowall stop --pidfile /tmp/cargowall.pid
+  artifacts:
+    when: always
+    paths:
+      - /tmp/cargowall.ndjson
+```
+
+`--gitlab-ci` bundles the iptables DNS redirect, Docker DNS interception, query filtering, cache pre-population, cloud metadata auto-allow, and GitLab host auto-allow. To use just a subset, pass the orthogonal flags individually (see the flag table above).
 
 ## Audit-then-enforce
 
@@ -230,16 +284,11 @@ sudo cargowall start \
 
 ## What's not in the standalone path
 
-The GitHub Action wraps the binary with a few extras you'd build yourself on other platforms:
+The orthogonal flags above cover most of what the GitHub Action wraps the binary with. The remaining Action-only piece is:
 
-* Automatic Docker DNS interception (rewrites `/etc/docker/daemon.json`)
-* iptables DNS redirect for processes that bypass `/etc/resolv.conf`
-* Sudo lockdown to prevent firewall bypass mid-run
-* Auto-allow for Azure IMDS / GitHub service hosts
-* Post-run audit summary correlating events with workflow step timings
-* Optional CodeCargo SaaS policy fetch and result push
+* Post-run audit summary correlating events with workflow step timings (the `cargowall summary` subcommand can run standalone too, but the GitHub-step JSON it expects is GH-specific)
 
-If you want any of these on a different platform, the implementation lives in [`cmd/`](./cmd/) and most pieces are individually reusable.
+If you want a richer wrapper for another CI platform, the implementation lives in [`cmd/`](./cmd/) and most pieces are individually reusable.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ build:
 
 `--gitlab-ci` bundles the iptables DNS redirect, Docker DNS interception, query filtering, cache pre-population, cloud metadata auto-allow, and GitLab host auto-allow. To use just a subset, pass the orthogonal flags individually (see the flag table above).
 
+**Tip**: `CARGOWALL_PIDFILE` is read by both `start` and `stop`. Setting it once as a CI variable lets both invocations agree on the path without repeating `--pidfile` in every step.
+
 ## Audit-then-enforce
 
 Start in audit mode, collect a few runs of NDJSON logs, then promote to enforce by removing `--audit-mode`:

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -104,6 +104,10 @@ type StartCmd struct {
 	// delegated to the shell (`cargowall start --pidfile X &`) — true Unix
 	// daemonization isn't worth the Go runtime complexity for CI use.
 	Pidfile string `help:"Write the cargowall process pid to this file (used with 'cargowall stop')" default:"" env:"CARGOWALL_PIDFILE"`
+
+	// ReadyFile path is shared with `cargowall wait-ready` via the same
+	// default and env var, so the two subcommands always agree.
+	ReadyFile string `help:"Path to write the readiness sentinel file" default:"/tmp/cargowall-ready" env:"CARGOWALL_READY_FILE"`
 }
 
 // CIMode is the active CI integration mode, derived from which preset flag

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -68,16 +68,28 @@ type StartCmd struct {
 
 	Token  string `help:"codecargo token" env:"CODECARGO_AUTH_TOKEN"`
 	ApiUrl string `help:"CodeCargo API URL to fetch policy from" name:"api-url" env:"CARGOWALL_API_URL"`
-	JobKey string `help:"GitHub Actions job key for job-level policy resolution" name:"job-key" env:"CARGOWALL_JOB_KEY"`
+	JobKey string `help:"CI job key for job-level policy resolution" name:"job-key" env:"CARGOWALL_JOB_KEY"`
 
 	// Runtime options
 	DisableDNSTracking bool   `help:"Disable DNS tracking and hostname resolution" default:"false"`
 	DNSUpstream        string `help:"Upstream DNS server to forward queries to" required:"" env:"CARGOWALL_DNS_UPSTREAM"`
 
-	// GitHub Actions mode
-	GithubAction bool `help:"Run in GitHub Actions mode" default:"false" env:"CARGOWALL_GITHUB_ACTION"`
+	// CI presets — bundles the orthogonal flags below with sensible defaults
+	// for the named CI environment.
+	GithubAction bool `help:"Run in GitHub Actions mode (preset: enables DNS redirect, Docker DNS interception, query filtering, cache pre-population, cloud metadata auto-allow, GitHub hosts auto-allow)" default:"false" env:"CARGOWALL_GITHUB_ACTION"`
+	GitlabCI     bool `help:"Run in GitLab CI mode (preset: enables DNS redirect, Docker DNS interception, query filtering, cache pre-population, cloud metadata auto-allow, GitLab hosts auto-allow)" name:"gitlab-ci" default:"false" env:"CARGOWALL_GITLAB_CI"`
 
-	// Sudo lockdown (GitHub Actions security hardening)
+	// Orthogonal CI plumbing flags — usable on any CI system (or standalone).
+	// Each is also implied by a CI preset above.
+	DNSRedirectIptables    bool `help:"Install iptables OUTPUT NAT rules redirecting outbound DNS (UDP+TCP/53) to the local proxy at 127.0.0.1:53" default:"false" env:"CARGOWALL_DNS_REDIRECT_IPTABLES"`
+	DockerDNSInterception  bool `help:"Listen on the Docker bridge IP for DNS, rewrite /etc/docker/daemon.json so containers use the proxy, and restart the Docker daemon" default:"false" env:"CARGOWALL_DOCKER_DNS_INTERCEPTION"`
+	DNSQueryFiltering      bool `help:"Filter DNS queries against the firewall policy (blocks DNS tunneling)" default:"false" env:"CARGOWALL_DNS_QUERY_FILTERING"`
+	PrepopulateDNSCache    bool `help:"Pre-populate the BPF allowlist from the systemd-resolved cache and existing TCP connections at startup" default:"false" env:"CARGOWALL_PREPOPULATE_DNS_CACHE"`
+	AutoAllowCloudMetadata bool `help:"Auto-allow cloud metadata endpoints (Azure wireserver/IMDS or GCP metadata server, auto-detected via systemd-resolved upstreams)" default:"false" env:"CARGOWALL_AUTO_ALLOW_CLOUD_METADATA"`
+	AutoAllowGitHubHosts   bool `help:"Auto-allow GitHub service hostnames (github.com, *.githubusercontent.com, etc.) and discover ACTIONS_* runtime URLs" default:"false" env:"CARGOWALL_AUTO_ALLOW_GITHUB_HOSTS"`
+	AutoAllowGitlabHosts   bool `help:"Auto-allow GitLab service hostnames (gitlab.com, registry.gitlab.com, etc.) and discover CI_* runtime URLs" default:"false" env:"CARGOWALL_AUTO_ALLOW_GITLAB_HOSTS"`
+
+	// Sudo lockdown (CI security hardening)
 	SudoLockdown      bool   `help:"Enable sudo lockdown to prevent firewall bypass" default:"false" env:"CARGOWALL_SUDO_LOCKDOWN"`
 	SudoAllowCommands string `help:"Comma-separated list of command paths to allow via sudo when lockdown is enabled (e.g. /usr/bin/apt-get,/usr/bin/docker)" default:"" env:"CARGOWALL_SUDO_ALLOW_COMMANDS"`
 
@@ -87,10 +99,61 @@ type StartCmd struct {
 
 	// Pre-existing connection handling
 	AllowExistingConnections bool `help:"Allow pre-existing TCP connections at startup (loads /proc/net/tcp{,6} IPs into allow maps)" default:"false" env:"CARGOWALL_ALLOW_EXISTING_CONNECTIONS"`
+
+	// Pidfile pairs with the `cargowall stop` subcommand. Backgrounding is
+	// delegated to the shell (`cargowall start --pidfile X &`) — true Unix
+	// daemonization isn't worth the Go runtime complexity for CI use.
+	Pidfile string `help:"Write the cargowall process pid to this file (used with 'cargowall stop')" default:"" env:"CARGOWALL_PIDFILE"`
 }
 
+// CIMode is the active CI integration mode, derived from which preset flag
+// was passed. Drives log labels and which auto-allow defaults are applied.
+type CIMode string
+
+const (
+	CIModeNone         CIMode = ""
+	CIModeGithubAction CIMode = "github_action"
+	CIModeGitlabCI     CIMode = "gitlab_ci"
+)
+
+// CIMode returns the active CI integration mode for this start invocation.
+// GitHub Actions takes precedence if both presets are set (shouldn't happen).
+func (c *StartCmd) CIMode() CIMode {
+	if c.GithubAction {
+		return CIModeGithubAction
+	}
+	if c.GitlabCI {
+		return CIModeGitlabCI
+	}
+	return CIModeNone
+}
+
+// AfterApply expands CI presets into the orthogonal flags they imply.
+// `--github-action` and `--gitlab-ci` are conveniences that turn on the
+// underlying plumbing flags so users don't have to enumerate each one.
 func (c *StartCmd) AfterApply() error {
+	if c.GithubAction {
+		c.applyCIPreset(true /* github */)
+	}
+	if c.GitlabCI {
+		c.applyCIPreset(false /* gitlab */)
+	}
 	return nil
+}
+
+// applyCIPreset turns on the plumbing flags shared by both CI presets, then
+// sets the host auto-allow flag specific to the named CI.
+func (c *StartCmd) applyCIPreset(github bool) {
+	c.DNSRedirectIptables = true
+	c.DockerDNSInterception = true
+	c.DNSQueryFiltering = true
+	c.PrepopulateDNSCache = true
+	c.AutoAllowCloudMetadata = true
+	if github {
+		c.AutoAllowGitHubHosts = true
+	} else {
+		c.AutoAllowGitlabHosts = true
+	}
 }
 
 func defaultLogger(debug bool) *slog.Logger {
@@ -144,6 +207,8 @@ func (c *StartCmd) Run(globals *Globals) error {
 
 type CLI struct {
 	Globals
-	Start   StartCmd   `cmd:"" help:"Start the Cargowall eBPF firewall"`
-	Summary SummaryCmd `cmd:"" help:"Generate audit summary correlating events with GitHub Actions steps"`
+	Start     StartCmd     `cmd:"" help:"Start the Cargowall eBPF firewall"`
+	Summary   SummaryCmd   `cmd:"" help:"Generate audit summary correlating events with GitHub Actions steps"`
+	WaitReady WaitReadyCmd `cmd:"" name:"wait-ready" help:"Block until the cargowall ready sentinel appears"`
+	Stop      StopCmd      `cmd:"" help:"Send SIGTERM to a daemonized cargowall process"`
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -128,30 +128,33 @@ func (c *StartCmd) CIMode() CIMode {
 	return CIModeNone
 }
 
-// AfterApply expands CI presets into the orthogonal flags they imply.
-// `--github-action` and `--gitlab-ci` are conveniences that turn on the
-// underlying plumbing flags so users don't have to enumerate each one.
+// AfterApply expands the active CI preset into the orthogonal flags it
+// implies. `--github-action` and `--gitlab-ci` are conveniences that turn
+// on the underlying plumbing flags so users don't have to enumerate each
+// one. The presets are mutually exclusive — if both are set, CIMode()'s
+// precedence rule (GitHub wins) is the single source of truth.
 func (c *StartCmd) AfterApply() error {
-	if c.GithubAction {
-		c.applyCIPreset(true /* github */)
-	}
-	if c.GitlabCI {
-		c.applyCIPreset(false /* gitlab */)
+	switch c.CIMode() {
+	case CIModeGithubAction:
+		c.applyCIPreset(CIModeGithubAction)
+	case CIModeGitlabCI:
+		c.applyCIPreset(CIModeGitlabCI)
 	}
 	return nil
 }
 
 // applyCIPreset turns on the plumbing flags shared by both CI presets, then
 // sets the host auto-allow flag specific to the named CI.
-func (c *StartCmd) applyCIPreset(github bool) {
+func (c *StartCmd) applyCIPreset(mode CIMode) {
 	c.DNSRedirectIptables = true
 	c.DockerDNSInterception = true
 	c.DNSQueryFiltering = true
 	c.PrepopulateDNSCache = true
 	c.AutoAllowCloudMetadata = true
-	if github {
+	switch mode {
+	case CIModeGithubAction:
 		c.AutoAllowGitHubHosts = true
-	} else {
+	case CIModeGitlabCI:
 		c.AutoAllowGitlabHosts = true
 	}
 }
@@ -165,6 +168,10 @@ func defaultLogger(debug bool) *slog.Logger {
 }
 
 func (c *StartCmd) Run(globals *Globals) error {
+	// GithubAction-only by design: the handler emits GitHub-specific
+	// `::error::` / `::warning::` workflow commands. GitLab CI has no
+	// equivalent log-formatting protocol, so --gitlab-ci falls through to
+	// the default JSON logger.
 	if c.GithubAction {
 		c.Logger = slog.New(NewGitHubActionsHandler(globals.Debug))
 	} else {
@@ -210,5 +217,5 @@ type CLI struct {
 	Start     StartCmd     `cmd:"" help:"Start the Cargowall eBPF firewall"`
 	Summary   SummaryCmd   `cmd:"" help:"Generate audit summary correlating events with GitHub Actions steps"`
 	WaitReady WaitReadyCmd `cmd:"" name:"wait-ready" help:"Block until the cargowall ready sentinel appears"`
-	Stop      StopCmd      `cmd:"" help:"Send SIGTERM to a daemonized cargowall process"`
+	Stop      StopCmd      `cmd:"" help:"Send SIGTERM to a backgrounded cargowall process and wait for it to exit"`
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -371,3 +371,15 @@ func TestStartCmd_CIMode_GithubBeatsGitlabWhenBothSet(t *testing.T) {
 	cmd := &StartCmd{GithubAction: true, GitlabCI: true}
 	assert.Equal(t, CIModeGithubAction, cmd.CIMode())
 }
+
+func TestStartCmd_AfterApply_BothPresetsSet_OnlyGithubHostsAllowed(t *testing.T) {
+	// Both presets set: AfterApply must follow CIMode() precedence and
+	// expand only the GitHub host-allow flag, not both. Otherwise the runtime
+	// auto-allows would silently widen beyond what the documented mode promises.
+	cmd := &StartCmd{GithubAction: true, GitlabCI: true}
+	require.NoError(t, cmd.AfterApply())
+
+	assert.True(t, cmd.AutoAllowGitHubHosts, "github-action wins, so GitHub hosts should be allowed")
+	assert.False(t, cmd.AutoAllowGitlabHosts, "GitLab hosts must NOT be allowed when GitHub preset wins")
+	assert.True(t, cmd.AutoAllowCloudMetadata, "shared plumbing should still be enabled")
+}

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -309,3 +309,65 @@ func TestStartCmd_Run_HooksWithNilInitLogger(t *testing.T) {
 	_, isJSON := cmd.Logger.Handler().(*slog.JSONHandler)
 	assert.True(t, isJSON)
 }
+
+// --- AfterApply: CI preset expansion ---
+
+func TestStartCmd_AfterApply_GithubActionExpandsOrthogonalFlags(t *testing.T) {
+	cmd := &StartCmd{GithubAction: true}
+	require.NoError(t, cmd.AfterApply())
+
+	assert.True(t, cmd.DNSRedirectIptables, "github-action should enable --dns-redirect-iptables")
+	assert.True(t, cmd.DockerDNSInterception, "github-action should enable --docker-dns-interception")
+	assert.True(t, cmd.DNSQueryFiltering, "github-action should enable --dns-query-filtering")
+	assert.True(t, cmd.PrepopulateDNSCache, "github-action should enable --prepopulate-dns-cache")
+	assert.True(t, cmd.AutoAllowCloudMetadata, "github-action should enable --auto-allow-cloud-metadata")
+	assert.True(t, cmd.AutoAllowGitHubHosts, "github-action should enable --auto-allow-github-hosts")
+	assert.False(t, cmd.AutoAllowGitlabHosts, "github-action must NOT enable --auto-allow-gitlab-hosts")
+	assert.Equal(t, CIModeGithubAction, cmd.CIMode())
+}
+
+func TestStartCmd_AfterApply_GitlabCIExpandsOrthogonalFlags(t *testing.T) {
+	cmd := &StartCmd{GitlabCI: true}
+	require.NoError(t, cmd.AfterApply())
+
+	assert.True(t, cmd.DNSRedirectIptables, "gitlab-ci should enable --dns-redirect-iptables")
+	assert.True(t, cmd.DockerDNSInterception, "gitlab-ci should enable --docker-dns-interception")
+	assert.True(t, cmd.DNSQueryFiltering, "gitlab-ci should enable --dns-query-filtering")
+	assert.True(t, cmd.PrepopulateDNSCache, "gitlab-ci should enable --prepopulate-dns-cache")
+	assert.True(t, cmd.AutoAllowCloudMetadata, "gitlab-ci should enable --auto-allow-cloud-metadata")
+	assert.True(t, cmd.AutoAllowGitlabHosts, "gitlab-ci should enable --auto-allow-gitlab-hosts")
+	assert.False(t, cmd.AutoAllowGitHubHosts, "gitlab-ci must NOT enable --auto-allow-github-hosts")
+	assert.Equal(t, CIModeGitlabCI, cmd.CIMode())
+}
+
+func TestStartCmd_AfterApply_NoPresetLeavesFlagsUnset(t *testing.T) {
+	cmd := &StartCmd{}
+	require.NoError(t, cmd.AfterApply())
+
+	assert.False(t, cmd.DNSRedirectIptables)
+	assert.False(t, cmd.DockerDNSInterception)
+	assert.False(t, cmd.DNSQueryFiltering)
+	assert.False(t, cmd.PrepopulateDNSCache)
+	assert.False(t, cmd.AutoAllowCloudMetadata)
+	assert.False(t, cmd.AutoAllowGitHubHosts)
+	assert.False(t, cmd.AutoAllowGitlabHosts)
+	assert.Equal(t, CIModeNone, cmd.CIMode())
+}
+
+func TestStartCmd_AfterApply_OrthogonalFlagsPreservedWhenSetExplicitly(t *testing.T) {
+	// User sets --dns-redirect-iptables alone (no preset). The flag should
+	// stay set after AfterApply runs.
+	cmd := &StartCmd{DNSRedirectIptables: true}
+	require.NoError(t, cmd.AfterApply())
+
+	assert.True(t, cmd.DNSRedirectIptables, "explicitly-set orthogonal flag should not be cleared")
+	assert.False(t, cmd.DockerDNSInterception, "other flags should remain false without a preset")
+	assert.Equal(t, CIModeNone, cmd.CIMode())
+}
+
+func TestStartCmd_CIMode_GithubBeatsGitlabWhenBothSet(t *testing.T) {
+	// Pathological config: both presets set. GitHub wins (arbitrary but
+	// stable). Documented so callers can rely on it.
+	cmd := &StartCmd{GithubAction: true, GitlabCI: true}
+	assert.Equal(t, CIModeGithubAction, cmd.CIMode())
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -62,11 +63,15 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 			"cap_bpf", caps.HasCAP_BPF,
 			"cap_net_admin", caps.HasCAP_NET_ADMIN)
 
-		if cmd.GithubAction {
-			// In GitHub Actions mode, provide actionable guidance
+		switch cmd.CIMode() {
+		case CIModeGithubAction:
 			logger.Error("eBPF is not supported on this runner. " +
 				"Self-hosted runners may need kernel 5.x+ and CAP_BPF/CAP_NET_ADMIN capabilities. " +
 				"GitHub-hosted runners require sudo privileges.")
+		case CIModeGitlabCI:
+			logger.Error("eBPF is not supported in this GitLab CI environment. " +
+				"GitLab SaaS runners run in privileged Docker containers but you may need a self-hosted runner with kernel 5.x+ " +
+				"and CAP_BPF/CAP_NET_ADMIN. Check your runner image's kernel version with `uname -r`.")
 		}
 
 		return cargowallEbpf.RequireCapabilities()
@@ -107,12 +112,12 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 			logger,
 		)
 
-		// In GitHub Actions mode, also listen on Docker bridge for container DNS
-		if cmd.GithubAction {
-			// Enable DNS query filtering to prevent DNS tunneling
+		if cmd.DNSQueryFiltering {
 			dnsServer.EnableQueryFiltering(true)
 			logger.Info("DNS query filtering enabled (blocks DNS tunneling)")
+		}
 
+		if cmd.DockerDNSInterception {
 			var err error
 			dockerBridgeIP, err = network.GetDockerBridgeIP()
 			if err != nil {
@@ -151,7 +156,7 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		// Set up iptables DNAT to force all outbound DNS through the proxy.
 		// This catches processes that bypass /etc/resolv.conf and query
 		// upstream DNS directly (e.g., Go's pure resolver, Node.js).
-		if cmd.GithubAction {
+		if cmd.DNSRedirectIptables {
 			if err := network.SetupDNSRedirect(logger); err != nil {
 				logger.Warn("Failed to set up DNS redirect (iptables)", "error", err)
 			} else {
@@ -186,8 +191,8 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 
 	// Now load configuration (DNS proxy is running so hostname resolution will work)
 	var apiPolicyLoaded bool
-	if cmd.GithubAction {
-		apiPolicyLoaded = loadGitHubActionsConfig(ctx, cmd, configMgr, auditLogger, dockerBridgeIP, logger)
+	if cmd.CIMode() != CIModeNone {
+		apiPolicyLoaded = loadCIConfig(ctx, cmd, configMgr, auditLogger, dockerBridgeIP, logger)
 	} else if hooks != nil && hooks.LoadPolicy != nil {
 		// Extension hook: load policy from external source (e.g., NATS state machine)
 		policy, hookSmClient, cleanup, err := hooks.LoadPolicy(ctx, cmd)
@@ -325,14 +330,12 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		// IMPORTANT: Apply rules to any hostnames we tracked before config was loaded
 		// This is needed because we may have already resolved hostnames (like NATS)
 		// before we had the rules to track them
-		if (hooks != nil && hooks.LoadPolicy != nil) || cmd.GithubAction {
+		if (hooks != nil && hooks.LoadPolicy != nil) || cmd.PrepopulateDNSCache {
 			dnsServer.ApplyRulesToTrackedHostnames()
 			logger.Info("Applied firewall rules to tracked hostnames")
 		}
 
-		if cmd.GithubAction {
-			autoAllowInfraHosts(cmd, configMgr, fw, logger)
-		}
+		applyAutoAllowHelpers(cmd, configMgr, fw, logger)
 
 		// Shared resolver that uses the systemd-resolved stub listener for
 		// looking up cached DNS entries. Used for existing-connection reverse
@@ -345,11 +348,8 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		}
 
 		var existingIPs []string
-		if cmd.GithubAction {
+		if cmd.PrepopulateDNSCache {
 			existingIPs = reverseDNSExistingConnections(configMgr, cacheResolver, logger)
-		}
-
-		if cmd.GithubAction {
 			prePopulateDNSCache(configMgr, dnsServer, cacheResolver, logger)
 		}
 
@@ -359,22 +359,23 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 	}
 
 	// Log appropriate config source
-	if apiPolicyLoaded {
+	switch {
+	case apiPolicyLoaded:
 		logger.Info("CargoWall TC firewall started",
 			"interface", ifname,
 			"config_source", "saas_api",
 			"api_url", cmd.ApiUrl,
 			"default_action", configMgr.GetDefaultAction())
-	} else if cmd.GithubAction {
+	case cmd.CIMode() != CIModeNone:
 		logger.Info("CargoWall TC firewall started",
 			"interface", ifname,
-			"config_source", "github_action",
+			"config_source", string(cmd.CIMode()),
 			"default_action", configMgr.GetDefaultAction())
-	} else if hooks != nil && hooks.LoadPolicy != nil {
+	case hooks != nil && hooks.LoadPolicy != nil:
 		logger.Info("CargoWall TC firewall started",
 			"interface", ifname,
 			"config_source", "hook")
-	} else {
+	default:
 		logger.Info("CargoWall TC firewall started",
 			"interface", ifname,
 			"config_source", "file",
@@ -397,7 +398,7 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 	// Restart Docker daemon so containers pick up the DNS configuration
 	// written to daemon.json by ConfigureDockerDNS. Docker's SIGHUP handler
 	// does NOT reload DNS settings — a full restart is required.
-	if cmd.GithubAction && dockerBridgeIP != "" {
+	if cmd.DockerDNSInterception && dockerBridgeIP != "" {
 		if err := network.RestartDockerDaemon(logger); err != nil {
 			logger.Warn("Failed to restart Docker daemon for DNS config", "error", err)
 		}
@@ -411,6 +412,20 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		if err := os.WriteFile("/tmp/cargowall-ready", nil, 0o660); err != nil {
 			return fmt.Errorf("writing ready file: %w", err)
 		}
+	}
+
+	// Write pidfile so `cargowall stop --pidfile X` can target this process.
+	// Done after the ready sentinel so a wait-ready/stop pair sees a coherent state.
+	if cmd.Pidfile != "" {
+		pidStr := strconv.Itoa(os.Getpid())
+		if err := os.WriteFile(cmd.Pidfile, []byte(pidStr+"\n"), 0o644); err != nil {
+			logger.Warn("Failed to write pidfile", "path", cmd.Pidfile, "error", err)
+		}
+		defer func() {
+			if err := os.Remove(cmd.Pidfile); err != nil && !errors.Is(err, os.ErrNotExist) {
+				logger.Warn("Failed to remove pidfile on shutdown", "path", cmd.Pidfile, "error", err)
+			}
+		}()
 	}
 
 	logger.Info("CargoWall ready")
@@ -446,7 +461,7 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 	}
 
 	// Restore Docker DNS configuration if we modified it
-	if cmd.GithubAction && dockerBridgeIP != "" {
+	if cmd.DockerDNSInterception && dockerBridgeIP != "" {
 		if err := network.RestoreDockerDNS(logger); err != nil {
 			logger.Warn("Failed to restore Docker DNS", "error", err)
 		}
@@ -455,12 +470,12 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 	return nil
 }
 
-// loadGitHubActionsConfig handles GitHub Actions config priority:
+// loadCIConfig handles CI config priority:
 // (1) SaaS API fetch + bootstrap + mode override + state file,
 // (2) env vars, (3) config file. Calls EnsureDNSAllowed at end.
 // Returns true if SaaS API policy was loaded. Mutates cmd.AuditMode in place.
-func loadGitHubActionsConfig(ctx context.Context, cmd *StartCmd, configMgr *config.Manager, auditLogger *events.AuditLogger, dockerBridgeIP string, logger *slog.Logger) bool {
-	logger.Info("Running in GitHub Actions mode")
+func loadCIConfig(ctx context.Context, cmd *StartCmd, configMgr *config.Manager, auditLogger *events.AuditLogger, dockerBridgeIP string, logger *slog.Logger) bool {
+	logger.Info("Running in CI mode", "mode", string(cmd.CIMode()))
 
 	var apiPolicyLoaded bool
 
@@ -539,62 +554,80 @@ func loadGitHubActionsConfig(ctx context.Context, cmd *StartCmd, configMgr *conf
 	return apiPolicyLoaded
 }
 
-// autoAllowInfraHosts detects and allows infrastructure hosts needed for
-// GitHub Actions: systemd-resolved upstreams, Azure wireserver, IMDS,
-// GitHub service hosts, Azure infra hosts, Actions runtime env vars,
-// and the CodeCargo API hostname.
-func autoAllowInfraHosts(cmd *StartCmd, configMgr *config.Manager, fw firewall.Firewall, logger *slog.Logger) {
-	// Ensure systemd-resolved upstream DNS servers are allowed through the
-	// firewall (needed for cache misses).
-	if resolvedUpstreams, err := detectSystemdResolvedUpstreams(); err == nil {
-		if len(resolvedUpstreams) > 0 {
-			configMgr.EnsureDNSAllowed(resolvedUpstreams)
-
-			// Auto-allow Azure wireserver on ports 53 (DNS), 80 (HTTP),
-			// and 32526 (health) for every Azure VM / GitHub-hosted runner.
-			// The upstream IPs from systemd-resolved on Azure are
-			// typically 168.63.129.16.
-			configMgr.EnsureInfraAllowed(resolvedUpstreams, []config.Port{
-				config.PortDNS,
-				config.PortHTTP,
-				config.PortWireServer,
-			})
-
-			if err := fw.UpdateAllowlistTC(configMgr); err != nil {
-				logger.Warn("Failed to update allowlist with resolved upstreams", "error", err)
-			}
-			logger.Info("Allowed systemd-resolved upstream DNS servers", "ips", resolvedUpstreams)
+// applyAutoAllowHelpers invokes each enabled auto-allow helper and updates
+// the BPF allowlist once at the end. The CodeCargo API allow runs whenever
+// --api-url is set (independent of CI mode) so the SaaS summary push works.
+func applyAutoAllowHelpers(cmd *StartCmd, configMgr *config.Manager, fw firewall.Firewall, logger *slog.Logger) {
+	ran := false
+	if cmd.AutoAllowCloudMetadata {
+		autoAllowCloudMetadata(configMgr, logger)
+		ran = true
+	}
+	if cmd.AutoAllowGitHubHosts {
+		autoAllowGitHubHosts(configMgr, logger)
+		ran = true
+	}
+	if cmd.AutoAllowGitlabHosts {
+		autoAllowGitlabHosts(configMgr, logger)
+		ran = true
+	}
+	if cmd.ApiUrl != "" {
+		autoAllowCodeCargoAPI(cmd.ApiUrl, configMgr, logger)
+		ran = true
+	}
+	if ran {
+		if err := fw.UpdateAllowlistTC(configMgr); err != nil {
+			logger.Warn("Failed to update allowlist with auto-allow rules", "error", err)
 		}
-	} else {
+	}
+}
+
+// autoAllowCloudMetadata allows the link-local cloud metadata endpoint
+// (169.254.169.254 on port 80, used by both Azure IMDS and GCP metadata)
+// plus systemd-resolved upstream DNS servers. If Azure-specific upstreams
+// are detected (168.63.129.16 wireserver) it also adds Azure wireserver
+// ports and Azure infrastructure hostnames.
+func autoAllowCloudMetadata(configMgr *config.Manager, logger *slog.Logger) {
+	resolvedUpstreams, err := detectSystemdResolvedUpstreams()
+	if err != nil {
 		logger.Debug("Could not detect systemd-resolved upstreams", "error", err)
+	} else if len(resolvedUpstreams) > 0 {
+		configMgr.EnsureDNSAllowed(resolvedUpstreams)
+		logger.Info("Allowed systemd-resolved upstream DNS servers", "ips", resolvedUpstreams)
 	}
 
-	// Also pre-allow Azure IMDS metadata endpoint (169.254.169.254).
-	// This link-local IP serves instance metadata over HTTP on all
-	// Azure VMs and GitHub-hosted runners and must not be blocked.
-	configMgr.EnsureInfraAllowed([]string{"169.254.169.254"}, []config.Port{config.PortHTTP})
+	// 169.254.169.254 is the link-local metadata IP on both Azure (IMDS) and
+	// GCP. Both serve metadata over HTTP/80 so a single allow covers either
+	// cloud. Tagged GCP because the Azure wireserver branch below adds the
+	// stronger Azure-specific allows when running on Azure.
+	configMgr.EnsureInfraAllowed([]string{"169.254.169.254"}, []config.Port{config.PortHTTP}, config.AutoAddedTypeGCPInfrastructure)
 
-	// Pre-allow ICMP to the Azure wire server (168.63.129.16). GitHub-hosted
-	// runners periodically ping this IP, so without an allow rule each ping
-	// produces an EventProtocolBlocked log line — functional but noisy.
-	// Kept as a separate rule from the TCP wire-server ports above: the port-map
-	// keys {ip, port, proto} are disjoint across TCP/UDP/ICMP so the two rules
-	// coexist without collision.
-	configMgr.EnsureInfraAllowed([]string{"168.63.129.16"}, []config.Port{config.PortICMP})
+	// Azure detection: the wireserver IP 168.63.129.16 is unique to Azure
+	// VMs (and to GitHub-hosted runners, which run on Azure).
+	azureDetected := false
+	for _, ip := range resolvedUpstreams {
+		if ip == "168.63.129.16" {
+			azureDetected = true
+			break
+		}
+	}
+	if !azureDetected {
+		return
+	}
 
-	// Auto-allow GitHub service hostnames on port 443.
-	// Defaults cover core GitHub domains; overridable via
-	// CARGOWALL_GITHUB_SERVICE_HOSTS env var (comma-separated).
-	githubHosts := []string{
-		"github.com", "api.github.com", "githubapp.com",
-		"actions.githubusercontent.com", "github.githubassets.com",
-	}
-	if env := os.Getenv("CARGOWALL_GITHUB_SERVICE_HOSTS"); env != "" {
-		githubHosts = splitAndTrimCSV(env)
-	}
-	for _, h := range githubHosts {
-		configMgr.EnsureHostnameAllowed(h, []config.Port{config.PortHTTPS}, config.AutoAddedTypeGitHubService)
-	}
+	// Auto-allow Azure wireserver on ports 53 (DNS), 80 (HTTP), and
+	// 32526 (health). The port-map keys {ip, port, proto} are disjoint
+	// across TCP/UDP/ICMP so the ICMP rule below coexists cleanly.
+	configMgr.EnsureInfraAllowed(resolvedUpstreams, []config.Port{
+		config.PortDNS,
+		config.PortHTTP,
+		config.PortWireServer,
+	}, config.AutoAddedTypeAzureInfrastructure)
+
+	// Pre-allow ICMP to the Azure wire server. GitHub-hosted runners
+	// periodically ping this IP — without an allow rule each ping produces
+	// an EventProtocolBlocked log line (functional but noisy).
+	configMgr.EnsureInfraAllowed([]string{"168.63.129.16"}, []config.Port{config.PortICMP}, config.AutoAddedTypeAzureInfrastructure)
 
 	// Auto-allow Azure infrastructure hostnames on port 443.
 	// Defaults cover blob storage and traffic manager; overridable
@@ -606,39 +639,89 @@ func autoAllowInfraHosts(cmd *StartCmd, configMgr *config.Manager, fw firewall.F
 	for _, h := range azureHosts {
 		configMgr.EnsureHostnameAllowed(h, []config.Port{config.PortHTTPS}, config.AutoAddedTypeAzureInfrastructure)
 	}
+}
 
-	// Auto-discover hostnames from GitHub Actions runtime environment
-	// variables. The runner communicates with specific subdomains like
-	// pipelines.actions.githubusercontent.com and results-receiver-service.
-	// actions.githubusercontent.com whose IPs differ from the parent
-	// domain's DNS resolution. Tracking them explicitly ensures Phase 1/2
-	// resolves their IPs into the BPF allowlist.
-	for _, envVar := range []string{
+// autoAllowGitHubHosts allows the default GitHub service hostnames plus any
+// hostnames discovered in the ACTIONS_* runtime environment variables.
+// Defaults are overridable via CARGOWALL_GITHUB_SERVICE_HOSTS.
+func autoAllowGitHubHosts(configMgr *config.Manager, logger *slog.Logger) {
+	githubHosts := []string{
+		"github.com", "api.github.com", "githubapp.com",
+		"actions.githubusercontent.com", "github.githubassets.com",
+	}
+	if env := os.Getenv("CARGOWALL_GITHUB_SERVICE_HOSTS"); env != "" {
+		githubHosts = splitAndTrimCSV(env)
+	}
+	for _, h := range githubHosts {
+		configMgr.EnsureHostnameAllowed(h, []config.Port{config.PortHTTPS}, config.AutoAddedTypeGitHubService)
+	}
+
+	// The runner communicates with specific subdomains like
+	// pipelines.actions.githubusercontent.com whose IPs differ from the
+	// parent domain's DNS resolution. Tracking them explicitly ensures
+	// Phase 1/2 resolves their IPs into the BPF allowlist.
+	autoAllowFromEnvURLs(configMgr, logger, config.AutoAddedTypeGitHubService, "Actions runtime", []string{
 		"ACTIONS_RUNTIME_URL",
 		"ACTIONS_RESULTS_URL",
 		"ACTIONS_CACHE_URL",
 		"ACTIONS_ID_TOKEN_REQUEST_URL",
-	} {
-		if val := os.Getenv(envVar); val != "" {
-			if u, err := url.Parse(val); err == nil && u.Hostname() != "" {
-				configMgr.EnsureHostnameAllowed(u.Hostname(), []config.Port{config.PortHTTPS}, config.AutoAddedTypeGitHubService)
-				logger.Info("Auto-allowed Actions runtime hostname", "env", envVar, "hostname", u.Hostname())
-			}
-		}
+	})
+}
+
+// autoAllowGitlabHosts allows the default GitLab service hostnames plus any
+// hostnames discovered in the CI_* runtime environment variables that
+// GitLab Runner exports into the job environment. Defaults are overridable
+// via CARGOWALL_GITLAB_SERVICE_HOSTS.
+func autoAllowGitlabHosts(configMgr *config.Manager, logger *slog.Logger) {
+	gitlabHosts := []string{
+		"gitlab.com",
+		"registry.gitlab.com",
+	}
+	if env := os.Getenv("CARGOWALL_GITLAB_SERVICE_HOSTS"); env != "" {
+		gitlabHosts = splitAndTrimCSV(env)
+	}
+	for _, h := range gitlabHosts {
+		configMgr.EnsureHostnameAllowed(h, []config.Port{config.PortHTTPS}, config.AutoAddedTypeGitLabService)
 	}
 
-	// Auto-allow the CodeCargo API hostname so the summary push
-	// (which runs while the firewall is active) is not blocked.
-	if cmd.ApiUrl != "" {
-		if u, err := url.Parse(cmd.ApiUrl); err == nil && u.Hostname() != "" {
-			configMgr.EnsureHostnameAllowed(u.Hostname(), []config.Port{config.PortHTTPS}, config.AutoAddedTypeCodeCargoService)
-			logger.Info("Auto-allowed CodeCargo API hostname", "hostname", u.Hostname())
-		}
-	}
+	autoAllowFromEnvURLs(configMgr, logger, config.AutoAddedTypeGitLabService, "GitLab CI runtime", []string{
+		"CI_SERVER_URL",
+		"CI_API_V4_URL",
+		"CI_REGISTRY",
+		"CI_REPOSITORY_URL",
+		"CI_PAGES_URL",
+		"CI_DEPENDENCY_PROXY_SERVER",
+		"CI_PROJECT_URL",
+	})
+}
 
-	if err := fw.UpdateAllowlistTC(configMgr); err != nil {
-		logger.Warn("Failed to update allowlist with infra rules", "error", err)
+// autoAllowFromEnvURLs reads each env var as a URL and adds an HTTPS allow
+// rule for its hostname. Used by both the GitHub and GitLab auto-allow paths
+// to discover runtime endpoints injected by the CI runner.
+func autoAllowFromEnvURLs(configMgr *config.Manager, logger *slog.Logger, autoAddedType config.AutoAddedType, label string, envVars []string) {
+	for _, envVar := range envVars {
+		val := os.Getenv(envVar)
+		if val == "" {
+			continue
+		}
+		u, err := url.Parse(val)
+		if err != nil || u.Hostname() == "" {
+			continue
+		}
+		configMgr.EnsureHostnameAllowed(u.Hostname(), []config.Port{config.PortHTTPS}, autoAddedType)
+		logger.Info("Auto-allowed "+label+" hostname", "env", envVar, "hostname", u.Hostname())
 	}
+}
+
+// autoAllowCodeCargoAPI allows the CodeCargo API hostname on 443 so the
+// summary push (which runs while the firewall is active) isn't blocked.
+func autoAllowCodeCargoAPI(apiURL string, configMgr *config.Manager, logger *slog.Logger) {
+	u, err := url.Parse(apiURL)
+	if err != nil || u.Hostname() == "" {
+		return
+	}
+	configMgr.EnsureHostnameAllowed(u.Hostname(), []config.Port{config.PortHTTPS}, config.AutoAddedTypeCodeCargoService)
+	logger.Info("Auto-allowed CodeCargo API hostname", "hostname", u.Hostname())
 }
 
 // reverseDNSExistingConnections scans existing TCP connections from

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -404,6 +404,31 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		}
 	}
 
+	// Write pidfile BEFORE the ready sentinel so a `wait-ready` then `stop
+	// --pidfile X` sequence never races.
+	//
+	// O_NOFOLLOW: cargowall typically runs as root. If a previous job on a
+	// shared self-hosted runner planted a symlink at the pidfile path
+	// pointing at e.g. /etc/hostname, a vanilla os.WriteFile would clobber
+	// the target. O_NOFOLLOW makes open() fail with ELOOP instead.
+	if cmd.Pidfile != "" {
+		pidStr := strconv.Itoa(os.Getpid())
+		f, err := os.OpenFile(cmd.Pidfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0o644)
+		if err != nil {
+			logger.Warn("Failed to open pidfile", "path", cmd.Pidfile, "error", err)
+		} else {
+			if _, err := f.WriteString(pidStr + "\n"); err != nil {
+				logger.Warn("Failed to write pidfile", "path", cmd.Pidfile, "error", err)
+			}
+			_ = f.Close()
+			defer func() {
+				if err := os.Remove(cmd.Pidfile); err != nil && !errors.Is(err, os.ErrNotExist) {
+					logger.Warn("Failed to remove pidfile on shutdown", "path", cmd.Pidfile, "error", err)
+				}
+			}()
+		}
+	}
+
 	if hooks != nil && hooks.Ready != nil {
 		if err := hooks.Ready(); err != nil {
 			return fmt.Errorf("ready hook failed: %w", err)
@@ -412,20 +437,6 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		if err := os.WriteFile("/tmp/cargowall-ready", nil, 0o660); err != nil {
 			return fmt.Errorf("writing ready file: %w", err)
 		}
-	}
-
-	// Write pidfile so `cargowall stop --pidfile X` can target this process.
-	// Done after the ready sentinel so a wait-ready/stop pair sees a coherent state.
-	if cmd.Pidfile != "" {
-		pidStr := strconv.Itoa(os.Getpid())
-		if err := os.WriteFile(cmd.Pidfile, []byte(pidStr+"\n"), 0o644); err != nil {
-			logger.Warn("Failed to write pidfile", "path", cmd.Pidfile, "error", err)
-		}
-		defer func() {
-			if err := os.Remove(cmd.Pidfile); err != nil && !errors.Is(err, os.ErrNotExist) {
-				logger.Warn("Failed to remove pidfile on shutdown", "path", cmd.Pidfile, "error", err)
-			}
-		}()
 	}
 
 	logger.Info("CargoWall ready")
@@ -591,7 +602,17 @@ func autoAllowCloudMetadata(configMgr *config.Manager, logger *slog.Logger) {
 	resolvedUpstreams, err := detectSystemdResolvedUpstreams()
 	if err != nil {
 		logger.Debug("Could not detect systemd-resolved upstreams", "error", err)
-	} else if len(resolvedUpstreams) > 0 {
+	}
+	applyCloudMetadataAllows(configMgr, resolvedUpstreams, logger)
+}
+
+// applyCloudMetadataAllows is the testable inner logic of
+// autoAllowCloudMetadata: given a (possibly empty) set of systemd-resolved
+// upstreams, populate the cloud metadata + Azure-specific allows. Split out
+// so unit tests can drive Azure vs GCP behavior without touching
+// /run/systemd/resolve/resolv.conf.
+func applyCloudMetadataAllows(configMgr *config.Manager, resolvedUpstreams []string, logger *slog.Logger) {
+	if len(resolvedUpstreams) > 0 {
 		configMgr.EnsureDNSAllowed(resolvedUpstreams)
 		logger.Info("Allowed systemd-resolved upstream DNS servers", "ips", resolvedUpstreams)
 	}
@@ -600,6 +621,10 @@ func autoAllowCloudMetadata(configMgr *config.Manager, logger *slog.Logger) {
 	// GCP. Both serve metadata over HTTP/80 so a single allow covers either
 	// cloud. Tagged GCP because the Azure wireserver branch below adds the
 	// stronger Azure-specific allows when running on Azure.
+	//
+	// On bare-metal hosts with no metadata service the BPF entry is a
+	// harmless no-op (nothing listens, no traffic flows). The deliberate
+	// trade-off is one no-op map entry vs. an invasive cloud-detection probe.
 	configMgr.EnsureInfraAllowed([]string{"169.254.169.254"}, []config.Port{config.PortHTTP}, config.AutoAddedTypeGCPInfrastructure)
 
 	// Azure detection: the wireserver IP 168.63.129.16 is unique to Azure
@@ -670,8 +695,10 @@ func autoAllowGitHubHosts(configMgr *config.Manager, logger *slog.Logger) {
 
 // autoAllowGitlabHosts allows the default GitLab service hostnames plus any
 // hostnames discovered in the CI_* runtime environment variables that
-// GitLab Runner exports into the job environment. Defaults are overridable
-// via CARGOWALL_GITLAB_SERVICE_HOSTS.
+// GitLab Runner exports into the job environment. The defaults assume
+// gitlab.com SaaS — self-hosted GitLab users should override them via
+// CARGOWALL_GITLAB_SERVICE_HOSTS. CI_SERVER_URL discovery below covers the
+// self-hosted endpoint regardless.
 func autoAllowGitlabHosts(configMgr *config.Manager, logger *slog.Logger) {
 	gitlabHosts := []string{
 		"gitlab.com",
@@ -697,8 +724,10 @@ func autoAllowGitlabHosts(configMgr *config.Manager, logger *slog.Logger) {
 
 // autoAllowFromEnvURLs reads each env var as a URL and adds an HTTPS allow
 // rule for its hostname. Used by both the GitHub and GitLab auto-allow paths
-// to discover runtime endpoints injected by the CI runner.
-func autoAllowFromEnvURLs(configMgr *config.Manager, logger *slog.Logger, autoAddedType config.AutoAddedType, label string, envVars []string) {
+// to discover runtime endpoints injected by the CI runner. The kind label
+// (e.g. "Actions runtime", "GitLab CI runtime") is logged so operators can
+// trace which discovery path produced a given allow.
+func autoAllowFromEnvURLs(configMgr *config.Manager, logger *slog.Logger, autoAddedType config.AutoAddedType, kind string, envVars []string) {
 	for _, envVar := range envVars {
 		val := os.Getenv(envVar)
 		if val == "" {
@@ -709,7 +738,7 @@ func autoAllowFromEnvURLs(configMgr *config.Manager, logger *slog.Logger, autoAd
 			continue
 		}
 		configMgr.EnsureHostnameAllowed(u.Hostname(), []config.Port{config.PortHTTPS}, autoAddedType)
-		logger.Info("Auto-allowed "+label+" hostname", "env", envVar, "hostname", u.Hostname())
+		logger.Info("Auto-allowed CI runtime hostname", "kind", kind, "env", envVar, "hostname", u.Hostname())
 	}
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,7 +27,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -407,26 +406,18 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 	// Write pidfile BEFORE the ready sentinel so a `wait-ready` then `stop
 	// --pidfile X` sequence never races.
 	//
-	// O_NOFOLLOW: cargowall typically runs as root. If a previous job on a
-	// shared self-hosted runner planted a symlink at the pidfile path
-	// pointing at e.g. /etc/hostname, a vanilla os.WriteFile would clobber
-	// the target. O_NOFOLLOW makes open() fail with ELOOP instead.
+	// Failure to write is fatal — the user opted into --pidfile expecting
+	// `cargowall stop` to work later; silently best-effort would leave them
+	// with a useful-looking startup but a broken teardown.
 	if cmd.Pidfile != "" {
-		pidStr := strconv.Itoa(os.Getpid())
-		f, err := os.OpenFile(cmd.Pidfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0o644)
-		if err != nil {
-			logger.Warn("Failed to open pidfile", "path", cmd.Pidfile, "error", err)
-		} else {
-			if _, err := f.WriteString(pidStr + "\n"); err != nil {
-				logger.Warn("Failed to write pidfile", "path", cmd.Pidfile, "error", err)
-			}
-			_ = f.Close()
-			defer func() {
-				if err := os.Remove(cmd.Pidfile); err != nil && !errors.Is(err, os.ErrNotExist) {
-					logger.Warn("Failed to remove pidfile on shutdown", "path", cmd.Pidfile, "error", err)
-				}
-			}()
+		if err := writePidfile(cmd.Pidfile, os.Getpid()); err != nil {
+			return fmt.Errorf("write pidfile %s: %w (cargowall stop --pidfile will not work)", cmd.Pidfile, err)
 		}
+		defer func() {
+			if err := os.Remove(cmd.Pidfile); err != nil && !errors.Is(err, os.ErrNotExist) {
+				logger.Warn("Failed to remove pidfile on shutdown", "path", cmd.Pidfile, "error", err)
+			}
+		}()
 	}
 
 	if hooks != nil && hooks.Ready != nil {
@@ -434,8 +425,8 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 			return fmt.Errorf("ready hook failed: %w", err)
 		}
 	} else {
-		if err := os.WriteFile("/tmp/cargowall-ready", nil, 0o660); err != nil {
-			return fmt.Errorf("writing ready file: %w", err)
+		if err := os.WriteFile(cmd.ReadyFile, nil, 0o660); err != nil {
+			return fmt.Errorf("writing ready file %s: %w", cmd.ReadyFile, err)
 		}
 	}
 

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -79,3 +79,74 @@ func TestGateExistingConnections_DeniedHostnameNotAdded(t *testing.T) {
 
 	gateExistingConnections([]string{"10.20.30.40"}, cm, fw, nil, quietLogger())
 }
+
+// hostnameRulesFor returns the allow-rule hostname strings tagged with the
+// given AutoAddedType, in declaration order.
+func hostnameRulesFor(t *testing.T, cm *config.Manager, want config.AutoAddedType) []string {
+	t.Helper()
+	var out []string
+	for _, r := range cm.GetResolvedRules() {
+		if r.Type == config.RuleTypeHostname && r.AutoAddedType == want && r.Action == config.ActionAllow {
+			out = append(out, r.Value)
+		}
+	}
+	return out
+}
+
+func TestAutoAllowGitlabHosts_DefaultsAndEnvDiscovery(t *testing.T) {
+	t.Setenv("CI_SERVER_URL", "https://gitlab.example.com")
+	t.Setenv("CI_REGISTRY", "https://registry.example.com")
+	t.Setenv("CI_API_V4_URL", "https://gitlab.example.com/api/v4")
+	t.Setenv("CI_PAGES_URL", "")
+	t.Setenv("CI_REPOSITORY_URL", "")
+	t.Setenv("CI_DEPENDENCY_PROXY_SERVER", "")
+	t.Setenv("CI_PROJECT_URL", "")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	autoAllowGitlabHosts(cm, quietLogger())
+
+	got := hostnameRulesFor(t, cm, config.AutoAddedTypeGitLabService)
+
+	// Defaults must be present.
+	require.Contains(t, got, "gitlab.com")
+	require.Contains(t, got, "registry.gitlab.com")
+	// Env-discovered hostnames must be present (deduplicated by EnsureHostnameAllowed).
+	require.Contains(t, got, "gitlab.example.com")
+	require.Contains(t, got, "registry.example.com")
+}
+
+func TestAutoAllowGitlabHosts_ServiceHostsEnvOverridesDefaults(t *testing.T) {
+	t.Setenv("CARGOWALL_GITLAB_SERVICE_HOSTS", "gitlab.internal,gitlab-runner.internal")
+	t.Setenv("CI_SERVER_URL", "")
+	t.Setenv("CI_REGISTRY", "")
+	t.Setenv("CI_API_V4_URL", "")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	autoAllowGitlabHosts(cm, quietLogger())
+
+	got := hostnameRulesFor(t, cm, config.AutoAddedTypeGitLabService)
+	require.Contains(t, got, "gitlab.internal")
+	require.Contains(t, got, "gitlab-runner.internal")
+	require.NotContains(t, got, "gitlab.com", "default hosts should be replaced when env override is set")
+}
+
+func TestAutoAllowGitHubHosts_RuntimeURLDiscovery(t *testing.T) {
+	t.Setenv("ACTIONS_RUNTIME_URL", "https://pipelines.actions.githubusercontent.com/abc/")
+	t.Setenv("ACTIONS_RESULTS_URL", "https://results-receiver.actions.githubusercontent.com")
+	t.Setenv("ACTIONS_CACHE_URL", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	autoAllowGitHubHosts(cm, quietLogger())
+
+	got := hostnameRulesFor(t, cm, config.AutoAddedTypeGitHubService)
+	require.Contains(t, got, "github.com")
+	require.Contains(t, got, "pipelines.actions.githubusercontent.com")
+	require.Contains(t, got, "results-receiver.actions.githubusercontent.com")
+}

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/code-cargo/cargowall/pkg/config"
@@ -132,6 +133,138 @@ func TestAutoAllowGitlabHosts_ServiceHostsEnvOverridesDefaults(t *testing.T) {
 	require.Contains(t, got, "gitlab.internal")
 	require.Contains(t, got, "gitlab-runner.internal")
 	require.NotContains(t, got, "gitlab.com", "default hosts should be replaced when env override is set")
+}
+
+// applyAutoAllowHelpers must NOT touch the firewall when no helper would
+// run — otherwise it'd push an unchanged allowlist on every call and waste
+// BPF map work for standalone users with no auto-allow flags set.
+func TestApplyAutoAllowHelpers_NoFlagsNoUpdate(t *testing.T) {
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	// NewMockFirewall(t) fails the test on any unexpected call, so the
+	// absence of an EXPECT() asserts UpdateAllowlistTC is never invoked.
+	fw := firewall.NewMockFirewall(t)
+
+	cmd := &StartCmd{} // every flag false, no ApiUrl
+	applyAutoAllowHelpers(cmd, cm, fw, quietLogger())
+}
+
+// When at least one helper runs, the dispatcher must call UpdateAllowlistTC
+// exactly once at the end (not once per helper).
+func TestApplyAutoAllowHelpers_AnyFlagTriggersSingleUpdate(t *testing.T) {
+	t.Setenv("CI_SERVER_URL", "")
+	t.Setenv("CI_REGISTRY", "")
+	t.Setenv("CI_API_V4_URL", "")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	fw := firewall.NewMockFirewall(t)
+	fw.EXPECT().UpdateAllowlistTC(mock.Anything).Return(nil).Once()
+
+	cmd := &StartCmd{AutoAllowGitlabHosts: true}
+	applyAutoAllowHelpers(cmd, cm, fw, quietLogger())
+}
+
+// ApiUrl alone (no CI flags) is enough to trigger the dispatcher because the
+// CodeCargo API allow runs whenever an api-url is set.
+func TestApplyAutoAllowHelpers_ApiUrlAloneTriggersUpdate(t *testing.T) {
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	fw := firewall.NewMockFirewall(t)
+	fw.EXPECT().UpdateAllowlistTC(mock.Anything).Return(nil).Once()
+
+	cmd := &StartCmd{ApiUrl: "https://api.codecargo.com"}
+	applyAutoAllowHelpers(cmd, cm, fw, quietLogger())
+
+	// And the API hostname should be in the resolved rules.
+	got := hostnameRulesFor(t, cm, config.AutoAddedTypeCodeCargoService)
+	require.Contains(t, got, "api.codecargo.com")
+}
+
+func TestApplyCloudMetadataAllows_NoUpstreamsGCPOnly(t *testing.T) {
+	t.Setenv("CARGOWALL_AZURE_INFRA_HOSTS", "")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	applyCloudMetadataAllows(cm, nil, quietLogger())
+
+	// Link-local metadata IP allowed on 80 — covers Azure IMDS and GCP both.
+	require.Equal(t, config.AutoAddedTypeGCPInfrastructure,
+		cm.GetAutoAllowedType("169.254.169.254", 80, ""))
+
+	// No Azure-specific rules added when no Azure wireserver in upstreams.
+	require.Equal(t, config.AutoAddedTypeNone,
+		cm.GetAutoAllowedType("168.63.129.16", 80, ""))
+	require.Empty(t, hostnameRulesFor(t, cm, config.AutoAddedTypeAzureInfrastructure))
+}
+
+func TestApplyCloudMetadataAllows_AzureDetectedAddsWireserver(t *testing.T) {
+	t.Setenv("CARGOWALL_AZURE_INFRA_HOSTS", "")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	applyCloudMetadataAllows(cm, []string{"168.63.129.16"}, quietLogger())
+
+	// Wireserver HTTP and health ports get the Azure tag. Port 53 is added
+	// by EnsureDNSAllowed first and tagged "dns"; GetAutoAllowedType is
+	// first-match-wins, so the later AzureInfrastructure rule is shadowed
+	// for port 53 only. Asserting both pins down the actual semantics.
+	for _, port := range []uint16{80, 32526} {
+		require.Equal(t, config.AutoAddedTypeAzureInfrastructure,
+			cm.GetAutoAllowedType("168.63.129.16", port, ""),
+			"168.63.129.16:%d should be auto-allowed as Azure infra", port)
+	}
+	require.Equal(t, config.AutoAddedTypeDNS,
+		cm.GetAutoAllowedType("168.63.129.16", 53, ""),
+		"168.63.129.16:53 is tagged DNS by EnsureDNSAllowed (first-match wins)")
+
+	// Azure infrastructure hostnames added.
+	azureHosts := hostnameRulesFor(t, cm, config.AutoAddedTypeAzureInfrastructure)
+	require.Contains(t, azureHosts, "trafficmanager.net")
+	require.Contains(t, azureHosts, "blob.core.windows.net")
+
+	// GCP-tagged metadata IP still allowed (the always-on baseline).
+	require.Equal(t, config.AutoAddedTypeGCPInfrastructure,
+		cm.GetAutoAllowedType("169.254.169.254", 80, ""))
+}
+
+func TestApplyCloudMetadataAllows_AzureHostsEnvOverride(t *testing.T) {
+	t.Setenv("CARGOWALL_AZURE_INFRA_HOSTS", "internal.example,corp.example")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	applyCloudMetadataAllows(cm, []string{"168.63.129.16"}, quietLogger())
+
+	azureHosts := hostnameRulesFor(t, cm, config.AutoAddedTypeAzureInfrastructure)
+	require.Contains(t, azureHosts, "internal.example")
+	require.Contains(t, azureHosts, "corp.example")
+	require.NotContains(t, azureHosts, "trafficmanager.net",
+		"default hosts should be replaced when env override is set")
+}
+
+// autoAllowFromEnvURLs must skip env values that parse as URLs without an
+// authority component (e.g. a bare hostname with no scheme), otherwise we'd
+// add a malformed empty-hostname rule and silently widen the policy.
+func TestAutoAllowFromEnvURLs_SkipsMalformedURLs(t *testing.T) {
+	t.Setenv("TEST_URL_BARE", "gitlab.example") // no scheme → u.Hostname() == ""
+	t.Setenv("TEST_URL_EMPTY", "")
+	t.Setenv("TEST_URL_VALID", "https://valid.example/path")
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+
+	autoAllowFromEnvURLs(cm, quietLogger(), config.AutoAddedTypeGitLabService, "test",
+		[]string{"TEST_URL_BARE", "TEST_URL_EMPTY", "TEST_URL_VALID"})
+
+	got := hostnameRulesFor(t, cm, config.AutoAddedTypeGitLabService)
+	require.Equal(t, []string{"valid.example"}, got,
+		"only the well-formed URL's hostname should be added")
 }
 
 func TestAutoAllowGitHubHosts_RuntimeURLDiscovery(t *testing.T) {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,94 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// StopCmd reads a pidfile written by `cargowall start --detach`, sends
+// SIGTERM to that process, and waits for it to exit (so subsequent CI
+// teardown steps can rely on iptables/Docker DNS having been restored).
+type StopCmd struct {
+	Pidfile string        `help:"Path to the pidfile written by 'cargowall start --detach'" default:"/run/cargowall.pid" env:"CARGOWALL_PIDFILE"`
+	Timeout time.Duration `help:"How long to wait for the process to exit after SIGTERM" default:"15s"`
+	Remove  bool          `help:"Remove the pidfile after a successful stop" default:"true"`
+}
+
+func (c *StopCmd) Run() error {
+	pid, err := readPidfile(c.Pidfile)
+	if err != nil {
+		return err
+	}
+	return stopProcess(pid, c.Timeout, c.Pidfile, c.Remove)
+}
+
+// readPidfile reads and parses a pidfile. Returns ErrNotExist wrapped if
+// the file is missing so callers can distinguish "already stopped" from
+// other errors.
+func readPidfile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("read pidfile %s: %w", path, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("invalid pid in %s: %q", path, string(data))
+	}
+	return pid, nil
+}
+
+// stopProcess sends SIGTERM and polls until the process exits or the
+// timeout fires. Removes the pidfile on success when remove is true.
+func stopProcess(pid int, timeout time.Duration, pidfile string, remove bool) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process %d: %w", pid, err)
+	}
+
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		// ESRCH means the process is already gone — treat that as success.
+		if errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone) {
+			if remove {
+				_ = os.Remove(pidfile)
+			}
+			return nil
+		}
+		return fmt.Errorf("send SIGTERM to %d: %w", pid, err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		// Signal 0 probes whether the process exists without delivering anything.
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			if remove {
+				_ = os.Remove(pidfile)
+			}
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("process %d did not exit within %s", pid, timeout)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -26,11 +26,11 @@ import (
 	"time"
 )
 
-// StopCmd reads a pidfile written by `cargowall start --detach`, sends
+// StopCmd reads a pidfile written by `cargowall start --pidfile X`, sends
 // SIGTERM to that process, and waits for it to exit (so subsequent CI
 // teardown steps can rely on iptables/Docker DNS having been restored).
 type StopCmd struct {
-	Pidfile string        `help:"Path to the pidfile written by 'cargowall start --detach'" default:"/run/cargowall.pid" env:"CARGOWALL_PIDFILE"`
+	Pidfile string        `help:"Path to the pidfile written by 'cargowall start --pidfile X'" required:"" env:"CARGOWALL_PIDFILE"`
 	Timeout time.Duration `help:"How long to wait for the process to exit after SIGTERM" default:"15s"`
 	Remove  bool          `help:"Remove the pidfile after a successful stop" default:"true"`
 }
@@ -66,12 +66,16 @@ func stopProcess(pid int, timeout time.Duration, pidfile string, remove bool) er
 		return fmt.Errorf("find process %d: %w", pid, err)
 	}
 
+	cleanup := func() {
+		if remove {
+			_ = os.Remove(pidfile)
+		}
+	}
+
 	if err := proc.Signal(syscall.SIGTERM); err != nil {
 		// ESRCH means the process is already gone — treat that as success.
 		if errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone) {
-			if remove {
-				_ = os.Remove(pidfile)
-			}
+			cleanup()
 			return nil
 		}
 		return fmt.Errorf("send SIGTERM to %d: %w", pid, err)
@@ -81,9 +85,7 @@ func stopProcess(pid int, timeout time.Duration, pidfile string, remove bool) er
 	for {
 		// Signal 0 probes whether the process exists without delivering anything.
 		if err := proc.Signal(syscall.Signal(0)); err != nil {
-			if remove {
-				_ = os.Remove(pidfile)
-			}
+			cleanup()
 			return nil
 		}
 		if time.Now().After(deadline) {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -58,6 +58,23 @@ func readPidfile(path string) (int, error) {
 	return pid, nil
 }
 
+// writePidfile writes pid as a decimal string + newline to path.
+//
+// O_NOFOLLOW is the load-bearing detail: cargowall typically runs as root,
+// and a previous job on a shared self-hosted runner could plant a symlink
+// at the pidfile path pointing at e.g. /etc/hostname. Without O_NOFOLLOW,
+// open() would follow the link and we'd silently clobber the target.
+// With O_NOFOLLOW the call fails with ELOOP — see TestWritePidfile_RefusesToFollowSymlink.
+func writePidfile(path string, pid int) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(strconv.Itoa(pid) + "\n")
+	return err
+}
+
 // stopProcess sends SIGTERM and polls until the process exits or the
 // timeout fires. Removes the pidfile on success when remove is true.
 func stopProcess(pid int, timeout time.Duration, pidfile string, remove bool) error {

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -1,0 +1,113 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestReadPidfile_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pid")
+	if err := os.WriteFile(path, []byte("12345\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pid, err := readPidfile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 12345 {
+		t.Fatalf("got pid %d, want 12345", pid)
+	}
+}
+
+func TestReadPidfile_Missing(t *testing.T) {
+	if _, err := readPidfile("/nonexistent/pidfile"); err == nil {
+		t.Fatal("expected error reading missing pidfile, got nil")
+	}
+}
+
+func TestReadPidfile_Invalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pid")
+	if err := os.WriteFile(path, []byte("not-a-number"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := readPidfile(path); err == nil {
+		t.Fatal("expected error parsing non-numeric pidfile, got nil")
+	}
+}
+
+func TestStopProcess_AlreadyExited(t *testing.T) {
+	// Pick a pid we're sure is not running.
+	dir := t.TempDir()
+	pidfile := filepath.Join(dir, "pid")
+	if err := os.WriteFile(pidfile, []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// stopProcess should treat ESRCH as success and remove the pidfile.
+	if err := stopProcess(999999, time.Second, pidfile, true); err != nil {
+		t.Fatalf("expected nil error for already-gone pid, got %v", err)
+	}
+	if _, err := os.Stat(pidfile); !os.IsNotExist(err) {
+		t.Fatalf("expected pidfile to be removed, stat err=%v", err)
+	}
+}
+
+func TestStopProcess_RealChild(t *testing.T) {
+	// Spawn a sleep we control. SIGTERM should reap it.
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not spawn helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	dir := t.TempDir()
+	pidfile := filepath.Join(dir, "pid")
+	if err := os.WriteFile(pidfile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reap in the background so the process actually disappears (otherwise it
+	// stays a zombie and Signal(0) keeps reporting it as alive).
+	done := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(done)
+	}()
+
+	if err := stopProcess(cmd.Process.Pid, 5*time.Second, pidfile, true); err != nil {
+		t.Fatalf("stopProcess returned error: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("helper process did not exit after SIGTERM")
+	}
+}

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -21,9 +21,64 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestWritePidfile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pid")
+
+	if err := writePidfile(path, 4242); err != nil {
+		t.Fatalf("writePidfile: %v", err)
+	}
+	got, err := readPidfile(path)
+	if err != nil {
+		t.Fatalf("readPidfile: %v", err)
+	}
+	if got != 4242 {
+		t.Fatalf("got pid %d, want 4242", got)
+	}
+}
+
+// O_NOFOLLOW is the *only* defense against the symlink-clobber attack
+// (a previous job on a shared self-hosted runner planting /tmp/cargowall.pid
+// as a symlink to /etc/hostname or similar). Pin the behavior so a future
+// refactor can't quietly drop the flag and leave the security gap open.
+func TestWritePidfile_RefusesToFollowSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "innocent-file")
+	pidfile := filepath.Join(dir, "pidfile")
+
+	original := []byte("important contents\n")
+	if err := os.WriteFile(target, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, pidfile); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writePidfile(pidfile, 9999)
+	if err == nil {
+		t.Fatal("writePidfile should fail when the path is a symlink, got nil")
+	}
+	if !strings.Contains(err.Error(), "too many levels of symbolic links") &&
+		!strings.Contains(err.Error(), "ELOOP") {
+		// On Linux, O_NOFOLLOW on a symlink returns ELOOP. Accept either the
+		// raw constant name or the message text the kernel produces.
+		t.Logf("note: error was %v (still a refusal, just unexpected wording)", err)
+	}
+
+	// The critical property: the symlink target must be unmodified.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read symlink target: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("symlink target was clobbered: got %q, want %q", string(got), string(original))
+	}
+}
 
 func TestReadPidfile_Valid(t *testing.T) {
 	dir := t.TempDir()

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -669,6 +669,12 @@ func auditEventToProto(e events.AuditEvent) *cargowallv1.CargoWallActionEvent {
 	return event
 }
 
+// mapAutoAllowedType converts an internal AutoAddedType string to the proto
+// enum used by the SaaS API push. Types not listed here (currently
+// "gcp_infrastructure" and "gitlab_service" — added in pkg/config without a
+// corresponding proto value) return ok=false, which causes the caller to
+// omit the AutoAllowedType field on the pushed event. A follow-up PR can
+// extend the proto and map them here.
 func mapAutoAllowedType(s string) (data.CargoWallAutoAllowedType, bool) {
 	switch s {
 	case "dns":

--- a/cmd/wait_ready.go
+++ b/cmd/wait_ready.go
@@ -1,0 +1,59 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// WaitReadyCmd blocks until cargowall writes its ready sentinel, or until
+// the timeout elapses. Used by shell-driven CI scripts to gate the build
+// step on the firewall being attached and the policy loaded.
+type WaitReadyCmd struct {
+	ReadyFile string        `help:"Path to the ready sentinel file" default:"/tmp/cargowall-ready" env:"CARGOWALL_READY_FILE"`
+	Timeout   time.Duration `help:"How long to wait before giving up" default:"30s"`
+	Interval  time.Duration `help:"Polling interval" default:"100ms"`
+}
+
+func (c *WaitReadyCmd) Run() error {
+	return waitForReady(c.ReadyFile, c.Timeout, c.Interval)
+}
+
+// waitForReady polls the sentinel path until it exists or the timeout fires.
+// Extracted so tests can drive it without going through kong.
+func waitForReady(path string, timeout, interval time.Duration) error {
+	if interval <= 0 {
+		interval = 100 * time.Millisecond
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		_, err := os.Stat(path)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for %s", timeout, path)
+		}
+		time.Sleep(interval)
+	}
+}

--- a/cmd/wait_ready_test.go
+++ b/cmd/wait_ready_test.go
@@ -1,0 +1,60 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWaitForReady_AlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ready")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := waitForReady(path, 100*time.Millisecond, 10*time.Millisecond); err != nil {
+		t.Fatalf("expected nil error when sentinel already exists, got %v", err)
+	}
+}
+
+func TestWaitForReady_AppearsBeforeTimeout(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ready")
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = os.WriteFile(path, nil, 0o644)
+	}()
+
+	if err := waitForReady(path, 500*time.Millisecond, 10*time.Millisecond); err != nil {
+		t.Fatalf("expected sentinel to appear before timeout, got %v", err)
+	}
+}
+
+func TestWaitForReady_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "never-appears")
+
+	err := waitForReady(path, 50*time.Millisecond, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,9 @@ const (
 	AutoAddedTypeNone                AutoAddedType = ""
 	AutoAddedTypeDNS                 AutoAddedType = "dns"
 	AutoAddedTypeAzureInfrastructure AutoAddedType = "azure_infrastructure"
+	AutoAddedTypeGCPInfrastructure   AutoAddedType = "gcp_infrastructure"
 	AutoAddedTypeGitHubService       AutoAddedType = "github_service"
+	AutoAddedTypeGitLabService       AutoAddedType = "gitlab_service"
 	AutoAddedTypeCodeCargoService    AutoAddedType = "codecargo_service"
 )
 
@@ -854,10 +856,10 @@ func (cm *Manager) EnsureDNSAllowed(ips []string) {
 }
 
 // EnsureInfraAllowed adds CIDR allow rules for the given IPs on the specified
-// ports, so infrastructure traffic (e.g. Azure wireserver/IMDS) is allowed
-// only on the ports it actually needs.
-func (cm *Manager) EnsureInfraAllowed(ips []string, ports []Port) {
-	cm.ensureAllowed(ips, ports, AutoAddedTypeAzureInfrastructure)
+// ports, tagged with the given AutoAddedType (e.g. AutoAddedTypeAzureInfrastructure
+// for Azure wireserver/IMDS, AutoAddedTypeGCPInfrastructure for GCP metadata).
+func (cm *Manager) EnsureInfraAllowed(ips []string, ports []Port, autoAddedType AutoAddedType) {
+	cm.ensureAllowed(ips, ports, autoAddedType)
 }
 
 // ensureAllowed adds CIDR allow rules for the given IPs with the specified ports.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -618,7 +618,7 @@ func TestEnsureInfraAllowed_SetsAutoAddedType(t *testing.T) {
 		t.Fatalf("LoadConfigFromRules() error = %v", err)
 	}
 
-	cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{{Port: 80, Protocol: ProtocolTCP}})
+	cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{{Port: 80, Protocol: ProtocolTCP}}, AutoAddedTypeAzureInfrastructure)
 
 	if len(cm.config.Rules) != 1 {
 		t.Fatalf("expected 1 rule, got %d", len(cm.config.Rules))
@@ -635,7 +635,7 @@ func TestEnsureInfraAllowed_ICMP(t *testing.T) {
 		t.Fatalf("LoadConfigFromRules() error = %v", err)
 	}
 
-	cm.EnsureInfraAllowed([]string{"168.63.129.16"}, []Port{PortICMP})
+	cm.EnsureInfraAllowed([]string{"168.63.129.16"}, []Port{PortICMP}, AutoAddedTypeAzureInfrastructure)
 
 	if len(cm.config.Rules) != 1 {
 		t.Fatalf("expected 1 rule, got %d", len(cm.config.Rules))
@@ -902,7 +902,7 @@ func TestGetAutoAllowedType(t *testing.T) {
 
 	// Add auto-added rules
 	cm.EnsureDNSAllowed([]string{"8.8.8.8"})
-	cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{{Port: 80, Protocol: ProtocolTCP}})
+	cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{{Port: 80, Protocol: ProtocolTCP}}, AutoAddedTypeAzureInfrastructure)
 	cm.EnsureHostnameAllowed("actions.githubusercontent.com", []Port{{Port: 443, Protocol: ProtocolTCP}}, AutoAddedTypeGitHubService)
 
 	// DNS rule should match on port 53


### PR DESCRIPTION
## Code changes

- `pkg/config/config.go` — added `AutoAddedTypeGCPInfrastructure` and `AutoAddedTypeGitLabService` constants; `EnsureInfraAllowed` now takes the auto-added-type as a parameter so callers can tag GCP vs Azure rules correctly.
- `cmd/flags.go` — added 7 orthogonal flags (`--dns-redirect-iptables`, `--docker-dns-interception`, `--dns-query-filtering`, `--prepopulate-dns-cache`, `--auto-allow-cloud-metadata`, `--auto-allow-github-hosts`, `--auto-allow-gitlab-hosts`), the `--gitlab-ci` preset, `--pidfile`, and `--ready-file` (path-shared with `wait-ready` via the same env var). `AfterApply` switches on `CIMode()` and expands the matching preset into the orthogonal flags — the two presets are mutually exclusive (GitHub wins if both are set). `WaitReadyCmd` and `StopCmd` are registered in the CLI struct.
- `cmd/start.go` — replaced all 11 `cmd.GithubAction` references with the appropriate orthogonal flag check; renamed `loadGitHubActionsConfig` → `loadCIConfig`; split `autoAllowInfraHosts` into `autoAllowCloudMetadata` (auto-detects Azure vs GCP via systemd-resolved upstreams) + `autoAllowGitHubHosts` + `autoAllowGitlabHosts` (new) + `autoAllowCodeCargoAPI`, plus a shared `autoAllowFromEnvURLs` helper. Pidfile is written **before** the ready sentinel (so `wait-ready` returning implies the pidfile exists) and pidfile-write failure is now **fatal** — `--pidfile` is an opt-in promise that `cargowall stop` will work, so silently best-effort would surprise the user.
- `cmd/stop.go` — extracted `writePidfile` helper (paired with `readPidfile`) using `os.OpenFile` with `O_NOFOLLOW` so a pre-planted symlink at the pidfile path can't be silently followed and clobbered. Also extracted the pidfile-removal helper to dedupe `stopProcess`.
- `cmd/wait_ready.go` — new subcommand that polls the sentinel with a timeout. Shares `--ready-file` / `CARGOWALL_READY_FILE` defaults with `start` so the two never disagree on the path.
- `cmd/summary.go` — doc note on `mapAutoAllowedType` flagging that the new `gcp_infrastructure` / `gitlab_service` types aren't yet in the proto enum, so events tagged with them have their `AutoAllowedType` field omitted from the SaaS push (follow-up to extend the proto).

## Tests

- `cmd/flags_test.go` — preset expansion (GitHub, GitLab, none, explicit-flag-preserved, both-set-precedence).
- `cmd/start_test.go` — `autoAllowGitlabHosts` defaults / env discovery / override; `autoAllowGitHubHosts` runtime URL discovery; `applyAutoAllowHelpers` dispatcher gating; `applyCloudMetadataAllows` GCP-only / Azure-detected / Azure host env override (pinning down the first-match-wins port-53 semantics); `autoAllowFromEnvURLs` malformed-URL skip.
- `cmd/wait_ready_test.go`, `cmd/stop_test.go` — already-exists / appears-before-timeout / times-out for `wait-ready`; pidfile parsing, write/read round-trip, **`O_NOFOLLOW` symlink-rejection** (pins the security property so a future refactor can't quietly drop the flag), SIGTERM-on-real-child + already-gone for `stop`.

## CI + docs

- `.github/workflows/ci.yml` — new `test-cargowall-gitlab-ci` job that exercises `--gitlab-ci`, `wait-ready`, and `stop` end-to-end. Uses a GitHub-hosted privileged Linux runner as the closest available stand-in for GitLab SaaS's privileged-container environment — see post-merge checklist below for real-environment validation.
- `README.md` — added a GitLab CI subsection with a copy-pasteable `.gitlab-ci.yml`, expanded the flag table with the 10 new flags, noted that `CARGOWALL_PIDFILE` is read by both `start` and `stop`, and shrank "What's not in the standalone path" since most pieces are now flag-accessible.

## Backwards compatibility

`--github-action` is preserved as a preset that expands to the same orthogonal flags, so `code-cargo/cargowall-action` keeps working unchanged. No coordinated release needed.

## Post-merge checklist

- [ ] Run a smoke `.gitlab-ci.yml` against gitlab.com SaaS shared runners with `--gitlab-ci --audit-mode` and confirm the audit log artifact looks sane (the in-PR CI job runs on a GH-Actions privileged-Linux stand-in, not the real GitLab SaaS environment).
- [ ] Open follow-up to extend the `CargoWallAutoAllowedType` proto with `gcp_infrastructure` / `gitlab_service` so those auto-allow tags survive the SaaS summary push.
- [ ] Open follow-up for the standard pidfile pid-reuse gotcha: if cargowall crashes (SIGKILL, OOM) without removing the pidfile and the kernel recycles the pid before `cargowall stop` runs, the unrelated process gets the SIGTERM. Mitigation: embed start time or `/proc/<pid>/comm` in the pidfile and validate before signaling.