### PR TITLE
#58 add clsact fallback

### DIFF
--- a/.github/workflows/bpf-generate.yml
+++ b/.github/workflows/bpf-generate.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -56,7 +56,7 @@ jobs:
       id-token: write
       checks: write
     steps:
-      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -95,7 +95,7 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -141,7 +141,7 @@ jobs:
         run: chmod +x bin/cargowall
 
       - name: Start CargoWall via Action
-        uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+        uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
         with:
           mode: enforce
           offline: 'true'
@@ -288,7 +288,7 @@ jobs:
         run: chmod +x bin/cargowall
 
       - name: Start CargoWall via Action
-        uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+        uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
         with:
           mode: audit
           offline: 'true'
@@ -875,6 +875,6 @@ jobs:
       - name: Make binary executable
         run: chmod +x bin/cargowall
 
-      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
         with:
           binary-path: ./bin/cargowall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install eBPF dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang llvm libbpf-dev
+          sudo apt-get install -y clang llvm libbpf-dev iproute2
 
       - name: Generate BPF objects
         run: go generate ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     steps:
-      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -70,7 +70,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
+      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -9,6 +9,7 @@ This file lists the dependencies used in this repository.
 | Go                                        | BSD-3-Clause | The Go Authors                              |
 | github.com/alecthomas/kong                | MIT          | Alec Thomas                                 |
 | github.com/cilium/ebpf                    | MIT          | Nathan Sweet, Cloudflare, Authors of Cilium |
+| github.com/mdlayher/netlink               | MIT          | Matt Layher                                 |
 | github.com/miekg/dns                      | BSD-3-Clause | The Go Authors, Miek Gieben                 |
 | github.com/stretchr/testify               | MIT          | Mat Ryer, Tyler Bunnell and contributors    |
 | golang.org/x/net                          | BSD-3-Clause | The Go Authors                              |
@@ -21,6 +22,9 @@ This file lists the dependencies used in this repository.
 | Dependency                    | License          | Copyright Owner               |
 |-------------------------------|------------------|-------------------------------|
 | github.com/davecgh/go-spew    | ISC              | Dave Collins                  |
+| github.com/google/go-cmp      | BSD-3-Clause     | The Go Authors                |
+| github.com/josharian/native   | MIT              | Josh Bleecher Snyder          |
+| github.com/mdlayher/socket    | MIT              | Matt Layher                   |
 | github.com/pmezard/go-difflib | BSD-3-Clause     | Patrick Mezard                |
 | github.com/stretchr/objx      | MIT              | Stretchr, Inc.                |
 | golang.org/x/mod              | BSD-3-Clause     | The Go Authors                |

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,13 @@ test:
 
 test-bpf:
 	@printf "${GREEN}Running BPF tests (requires root)...${RESET}\n"
-	sudo go test -v -count=1 ./bpf/
+	sudo go test -v -count=1 ./bpf/ ./pkg/tc/
 
 test-ci:
 	@printf "${GREEN}Running CI tests...${RESET}\n"
 	go run gotest.tools/gotestsum@latest --junitfile test-results.xml --format testdox -- ./...
 	@printf "${GREEN}Running BPF tests with sudo...${RESET}\n"
-	sudo go run gotest.tools/gotestsum@latest --junitfile test-results-bpf.xml --format testdox -- -count=1 ./bpf/
+	sudo go run gotest.tools/gotestsum@latest --junitfile test-results-bpf.xml --format testdox -- -count=1 ./bpf/ ./pkg/tc/
 
 vet:
 	$(call check_tool,staticcheck)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ CargoWall's runtime is a self-contained Linux binary — the GitHub Actions inte
 
 ## Requirements
 
-* Linux kernel **5.x or newer** (eBPF TC + cgroup hooks)
+* Linux kernel **5.8 or newer** (eBPF TC + cgroup hooks). CargoWall attaches its egress filter via the modern TCX hook on kernel 6.6+ and automatically falls back to the legacy `clsact` qdisc on 5.8–6.5, so older LTS kernels are supported. (5.8 is the floor because the in-kernel event ring buffer requires it.)
 * `CAP_BPF` and `CAP_NET_ADMIN` (typically run as root, or via capabilities/systemd)
 * An upstream DNS server CargoWall can forward queries to
 * Ports `53/udp` and `53/tcp` available on `127.0.0.1` for the local DNS proxy (the proxy starts listeners on both)
@@ -251,14 +251,14 @@ When CargoWall is ready, it writes a `/tmp/cargowall-ready` sentinel. Use the `c
 
 ## GitLab CI
 
-GitLab SaaS Linux runners give your job root inside a privileged Docker container, which is enough for eBPF — but you'll want to run a smoke job first to confirm `cargowall start --gitlab-ci` actually attaches in your project's runner image. Self-hosted runners with a recent kernel are the well-trodden path.
+GitLab SaaS Linux runners give your job root inside a privileged Docker container, which is enough for eBPF. SaaS shared runners run a 5.15 kernel, which predates the TCX hook — CargoWall detects this and attaches its egress filter through the legacy `clsact` path automatically, so `cargowall start --gitlab-ci` works on SaaS runners as-is. Self-hosted runners on a 6.6+ kernel use the faster TCX attach.
 
 ```yaml
 variables:
-  CARGOWALL_VERSION: v1.2.0
+  CARGOWALL_VERSION: v1.3.0
 
 build:
-  tags: [self-hosted-linux]   # or remove for SaaS shared runners (see caveats above)
+  tags: [self-hosted-linux]   # or remove for SaaS shared runners (clsact fallback)
   before_script:
     - curl -fsSL -o /usr/local/bin/cargowall https://github.com/code-cargo/cargowall/releases/download/${CARGOWALL_VERSION}/cargowall-linux-amd64
     - chmod +x /usr/local/bin/cargowall

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -48,6 +48,7 @@ import (
 	"github.com/code-cargo/cargowall/pkg/firewall"
 	"github.com/code-cargo/cargowall/pkg/lockdown"
 	"github.com/code-cargo/cargowall/pkg/network"
+	"github.com/code-cargo/cargowall/pkg/tc"
 )
 
 func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
@@ -67,12 +68,13 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		switch cmd.CIMode() {
 		case CIModeGithubAction:
 			logger.Error("eBPF is not supported on this runner. " +
-				"Self-hosted runners may need kernel 5.x+ and CAP_BPF/CAP_NET_ADMIN capabilities. " +
+				"Self-hosted runners may need kernel 5.8+ and CAP_BPF/CAP_NET_ADMIN capabilities. " +
 				"GitHub-hosted runners require sudo privileges.")
 		case CIModeGitlabCI:
 			logger.Error("eBPF is not supported in this GitLab CI environment. " +
-				"GitLab SaaS runners run in privileged Docker containers but you may need a self-hosted runner with kernel 5.x+ " +
-				"and CAP_BPF/CAP_NET_ADMIN. Check your runner image's kernel version with `uname -r`.")
+				"GitLab SaaS runners run in privileged Docker containers and attach fine on the 5.15 SaaS kernel " +
+				"(cargowall falls back to legacy clsact below kernel 6.6), so this usually means a kernel older than 5.8 " +
+				"or missing CAP_BPF/CAP_NET_ADMIN. Check your runner image's kernel version with `uname -r`.")
 		}
 
 		return cargowallEbpf.RequireCapabilities()
@@ -311,7 +313,7 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 	go events.ProcessBlockedEvents(rd, configMgr, notificationTracker, auditLogger, fw, logger)
 
 	// Attach TC programs
-	egressLink, err := network.AttachTC(ifname, objs.TcEgress, ebpf.AttachTCXEgress, logger)
+	egressLink, err := tc.AttachEgress(ifname, objs.TcEgress, logger)
 	if err != nil {
 		return fmt.Errorf("failed to attach TC egress: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/cilium/ebpf v0.21.0
+	github.com/mdlayher/netlink v1.7.2
 	github.com/miekg/dns v1.1.72
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.54.0
@@ -15,6 +16,9 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/josharian/native v1.1.0 // indirect
+	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	golang.org/x/mod v0.36.0 // indirect

--- a/pkg/ebpf/detect.go
+++ b/pkg/ebpf/detect.go
@@ -76,7 +76,8 @@ func Detect() *Capabilities {
 	}
 	caps.KernelVersion = int8ArrayToString(uname.Release[:])
 
-	// Check kernel version (need 5.x+ for TCX, 4.15+ for basic TC)
+	// Check kernel version (need 5.8+ for the event ring buffer; the TC attach
+	// path itself falls back to clsact below 6.6)
 	caps.KernelSupported = isKernelSupported(caps.KernelVersion)
 
 	// Check capabilities
@@ -92,10 +93,12 @@ func Detect() *Capabilities {
 	return caps
 }
 
-// isKernelSupported checks if the kernel version supports eBPF TC programs.
-// TCX (the modern TC attachment method) requires kernel 6.6+
-// TC BPF (legacy) requires kernel 4.15+
-// We target 5.x+ as a reasonable minimum for GitHub Actions runners
+// isKernelSupported reports whether the running kernel meets cargowall's floor.
+//
+// The hard floor is 5.8: bpf/tcbpf.c declares map_events as BPF_MAP_TYPE_RINGBUF
+// and the ring buffer landed in 5.8. The TC attach mechanism is NOT the
+// constraint — TCX (6.6+) is preferred, but pkg/tc transparently falls back to
+// the legacy clsact qdisc (4.5+), so kernels 5.8–6.5 are fully supported.
 func isKernelSupported(version string) bool {
 	var major, minor int
 	_, err := fmt.Sscanf(version, "%d.%d", &major, &minor)
@@ -103,15 +106,13 @@ func isKernelSupported(version string) bool {
 		return false
 	}
 
-	// Require kernel 5.0 or newer for eBPF TC support
-	// GitHub Actions runners typically run Ubuntu 22.04 with kernel 6.x
-	if major >= 6 {
-		return true
+	if major > 5 {
+		return true // 6.x and newer
 	}
 	if major == 5 {
-		return true
+		return minor >= 8 // 5.8+ for ringbuf; 5.0–5.7 rejected
 	}
-	return false
+	return false // 4.x and older
 }
 
 // hasCapability checks if the current process has the specified capability
@@ -200,7 +201,7 @@ func RequireCapabilities() error {
 	var reasons []string
 
 	if !caps.KernelSupported {
-		reasons = append(reasons, fmt.Sprintf("kernel %s is not supported (need 5.x+)", caps.KernelVersion))
+		reasons = append(reasons, fmt.Sprintf("kernel %s is not supported (need 5.8+)", caps.KernelVersion))
 	}
 
 	if !caps.BPFSyscall {

--- a/pkg/ebpf/detect_test.go
+++ b/pkg/ebpf/detect_test.go
@@ -1,0 +1,48 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package ebpf
+
+import "testing"
+
+func TestIsKernelSupported(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"4.19 too old", "4.19.0", false},
+		{"5.4 LTS pre-ringbuf", "5.4.0-100-generic", false},
+		{"5.7 just below floor", "5.7.0", false},
+		{"5.8 exact floor", "5.8.0", true},
+		{"5.10 LTS", "5.10.0", true},
+		{"5.15 GitLab SaaS aws", "5.15.0-1234-aws", true},
+		{"5.15 azure", "5.15.0-1019-azure", true},
+		{"6.0", "6.0.0", true},
+		{"6.6 tcx era", "6.6.0", true},
+		{"6.8 generic", "6.8.0-31-generic", true},
+		{"empty", "", false},
+		{"garbage", "notakernel", false},
+		{"leading v not parseable", "v5.15", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKernelSupported(tt.version); got != tt.want {
+				t.Errorf("isKernelSupported(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -18,11 +18,7 @@ package network
 
 import (
 	"fmt"
-	"log/slog"
 	"net"
-
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/link"
 )
 
 // FindPodInterface finds the pod's primary network interface
@@ -50,25 +46,4 @@ func FindPodInterface() (string, error) {
 	}
 
 	return "", fmt.Errorf("no suitable network interface found")
-}
-
-// AttachTC attaches the TC BPF program to the network interface
-func AttachTC(ifname string, prog *ebpf.Program, attachType ebpf.AttachType, logger *slog.Logger) (link.Link, error) {
-	// Get the network interface index
-	iface, err := net.InterfaceByName(ifname)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get interface %s: %w", ifname, err)
-	}
-
-	l, err := link.AttachTCX(link.TCXOptions{
-		Interface: iface.Index,
-		Program:   prog,
-		Attach:    attachType,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach TC %s: %w", attachType, err)
-	}
-
-	logger.Info("Attached TC program", "direction", attachType, "interface", ifname)
-	return l, nil
 }

--- a/pkg/tc/attach.go
+++ b/pkg/tc/attach.go
@@ -52,8 +52,11 @@ func AttachEgress(ifname string, prog *ebpf.Program, logger *slog.Logger) (io.Cl
 		return l, nil
 	}
 	if !errors.Is(err, ebpf.ErrNotSupported) {
-		// A real failure (permissions, bad program, busy interface): surface it
-		// rather than silently falling back.
+		// AttachTCX runs cilium's haveTCX() feature probe on failure and returns
+		// ebpf.ErrNotSupported whenever TCX is absent (kernels <6.6). A raw
+		// EOPNOTSUPP/EINVAL reaching here therefore means TCX *is* supported but
+		// the attach genuinely failed (permissions, bad program, busy interface) —
+		// surface it rather than silently falling back to clsact.
 		return nil, fmt.Errorf("attach TCX egress: %w", err)
 	}
 

--- a/pkg/tc/attach.go
+++ b/pkg/tc/attach.go
@@ -1,0 +1,67 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+// Package tc attaches cargowall's egress eBPF classifier to a network
+// interface, preferring the modern TCX hook and transparently falling back to
+// the legacy clsact qdisc on older kernels.
+package tc
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+// AttachEgress attaches prog to the named interface's egress TC hook.
+//
+// It prefers TCX (the modern bpf_link TC hook, kernel 6.6+). On older kernels
+// link.AttachTCX reports ebpf.ErrNotSupported, and we fall back to the legacy
+// clsact qdisc + direct-action cls_bpf filter (kernel 4.5+). The returned
+// io.Closer detaches the program on Close, regardless of which path was taken.
+func AttachEgress(ifname string, prog *ebpf.Program, logger *slog.Logger) (io.Closer, error) {
+	iface, err := net.InterfaceByName(ifname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get interface %s: %w", ifname, err)
+	}
+
+	l, err := link.AttachTCX(link.TCXOptions{
+		Interface: iface.Index,
+		Program:   prog,
+		Attach:    ebpf.AttachTCXEgress,
+	})
+	if err == nil {
+		logger.Info("Attached TC egress program", "interface", ifname, "method", "tcx")
+		return l, nil
+	}
+	if !errors.Is(err, ebpf.ErrNotSupported) {
+		// A real failure (permissions, bad program, busy interface): surface it
+		// rather than silently falling back.
+		return nil, fmt.Errorf("attach TCX egress: %w", err)
+	}
+
+	logger.Info("TCX unsupported on this kernel, falling back to legacy clsact", "interface", ifname)
+	closer, err := attachClsactEgress(iface.Index, prog, logger)
+	if err != nil {
+		return nil, fmt.Errorf("attach legacy clsact egress: %w", err)
+	}
+	logger.Info("Attached TC egress program", "interface", ifname, "method", "clsact")
+	return closer, nil
+}

--- a/pkg/tc/clsact_linux.go
+++ b/pkg/tc/clsact_linux.go
@@ -1,0 +1,233 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package tc
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"runtime"
+
+	"github.com/cilium/ebpf"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// TC handle/parent constants. These are spelled out explicitly (rather than
+// computed via TC_H_MAKE-style macros) because the exact values are the part
+// that trips people up.
+const (
+	// clsactParent is TC_H_CLSACT — the parent under which a clsact qdisc lives.
+	clsactParent = 0xFFFFFFF1
+	// clsactHandle is the clsact qdisc handle: major 0xFFFF, minor 0.
+	clsactHandle = 0xFFFF0000
+	// egressParent is TC_H_MAKE(TC_H_CLSACT, TC_H_MIN_EGRESS) — the egress hook.
+	egressParent = 0xFFFFFFF3
+
+	// cwFilterPrio is a distinctive filter priority so teardown can target
+	// exactly cargowall's filter without disturbing anything else on the qdisc.
+	cwFilterPrio = 0xC150
+	// cwFilterHandle is the filter handle within the priority.
+	cwFilterHandle = 1
+	// cwFilterName is surfaced by `tc filter show` via TCA_BPF_NAME.
+	cwFilterName = "cargowall_egress"
+
+	// TCA_BPF_* attribute types are stable kernel UAPI (linux/pkt_cls.h) but are
+	// not exported by x/sys/unix, so we define them here.
+	tcaBPFFD    = 6 // TCA_BPF_FD
+	tcaBPFName  = 7 // TCA_BPF_NAME
+	tcaBPFFlags = 8 // TCA_BPF_FLAGS
+
+	// bpfFlagActDirect is TCA_BPF_FLAG_ACT_DIRECT: run the program in
+	// direct-action mode so its return code (TC_ACT_OK / TC_ACT_SHOT) is the
+	// verdict. Without it, cls_bpf treats the return value as a classid and
+	// TC_ACT_SHOT would NOT drop — i.e. the firewall would silently fail open.
+	// TCX is always direct-action, which is why the TCX path sets no flag.
+	bpfFlagActDirect = 1
+)
+
+// tcMsg is the netlink tcmsg header (struct tcmsg, linux/rtnetlink.h): 20 bytes.
+type tcMsg struct {
+	family  uint8
+	ifindex int32
+	handle  uint32
+	parent  uint32
+	info    uint32
+}
+
+// marshal encodes the tcmsg in native byte order. Bytes 1-3 are padding.
+func (m tcMsg) marshal() []byte {
+	b := make([]byte, 20)
+	b[0] = m.family
+	binary.NativeEndian.PutUint32(b[4:8], uint32(m.ifindex))
+	binary.NativeEndian.PutUint32(b[8:12], m.handle)
+	binary.NativeEndian.PutUint32(b[12:16], m.parent)
+	binary.NativeEndian.PutUint32(b[16:20], m.info)
+	return b
+}
+
+// htons converts v from host to network byte order (identity on big-endian).
+func htons(v uint16) uint16 {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], v)     // network order
+	return binary.NativeEndian.Uint16(b[:]) // reinterpret in host order
+}
+
+// makeFilterInfo packs a tcmsg info field for a filter: priority in the high 16
+// bits, protocol (network byte order) in the low 16 bits.
+func makeFilterInfo(prio, proto uint16) uint32 {
+	return uint32(prio)<<16 | uint32(htons(proto))
+}
+
+// encodeEgressFilterAttrs builds the rtnetlink attributes for a direct-action
+// cls_bpf egress filter referencing the program file descriptor fd. Extracted
+// so the (security-critical) direct-action encoding is unit-testable.
+func encodeEgressFilterAttrs(fd uint32) ([]byte, error) {
+	ae := netlink.NewAttributeEncoder()
+	ae.String(unix.TCA_KIND, "bpf")
+	ae.Nested(unix.TCA_OPTIONS, func(nae *netlink.AttributeEncoder) error {
+		nae.Uint32(tcaBPFFD, fd)
+		nae.String(tcaBPFName, cwFilterName)
+		nae.Uint32(tcaBPFFlags, bpfFlagActDirect)
+		return nil
+	})
+	return ae.Encode()
+}
+
+// execTC sends a single tc netlink request and waits for the kernel's ack,
+// returning the (possibly errno-wrapping) error. Request|Acknowledge are always
+// set; flags adds the per-operation bits (Create/Excl/Replace).
+func execTC(conn *netlink.Conn, typ uint16, flags netlink.HeaderFlags, m tcMsg, attrs []byte) error {
+	_, err := conn.Execute(netlink.Message{
+		Header: netlink.Header{
+			Type:  netlink.HeaderType(typ),
+			Flags: netlink.Request | netlink.Acknowledge | flags,
+		},
+		Data: append(m.marshal(), attrs...),
+	})
+	return err
+}
+
+// attachClsactEgress attaches prog to the interface's egress hook via the legacy
+// clsact qdisc + direct-action cls_bpf filter (the pre-TCX mechanism, kernel
+// 4.5+). It is the fallback used by AttachEgress on kernels without TCX (< 6.6).
+//
+// The clsact qdisc is created only if absent, and we record whether we created
+// it so teardown removes only a qdisc we own (libbpf-style) — a qdisc installed
+// by another tool (e.g. Cilium) is left in place.
+func attachClsactEgress(ifindex int, prog *ebpf.Program, logger *slog.Logger) (io.Closer, error) {
+	conn, err := netlink.Dial(unix.NETLINK_ROUTE, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial netlink: %w", err)
+	}
+	defer conn.Close()
+
+	// 1. Ensure the clsact qdisc exists (create-if-missing via CREATE|EXCL).
+	clsactAttrs := netlink.NewAttributeEncoder()
+	clsactAttrs.String(unix.TCA_KIND, "clsact")
+	clsactData, err := clsactAttrs.Encode()
+	if err != nil {
+		return nil, fmt.Errorf("encode clsact qdisc attrs: %w", err)
+	}
+	qmsg := tcMsg{family: unix.AF_UNSPEC, ifindex: int32(ifindex), handle: clsactHandle, parent: clsactParent}
+
+	createdQdisc := false
+	switch err := execTC(conn, unix.RTM_NEWQDISC, netlink.Create|netlink.Excl, qmsg, clsactData); {
+	case err == nil:
+		createdQdisc = true
+	case errors.Is(err, unix.EEXIST):
+		// A clsact qdisc is already present (prior run or another tool); reuse it.
+	default:
+		return nil, fmt.Errorf("create clsact qdisc: %w", err)
+	}
+
+	// 2. Attach the program as a direct-action cls_bpf egress filter. REPLACE
+	//    makes a restart idempotent over a stale filter from a crashed run.
+	filterData, err := encodeEgressFilterAttrs(uint32(prog.FD()))
+	if err != nil {
+		return nil, fmt.Errorf("encode egress filter attrs: %w", err)
+	}
+	fmsg := tcMsg{
+		family:  unix.AF_UNSPEC,
+		ifindex: int32(ifindex),
+		handle:  cwFilterHandle,
+		parent:  egressParent,
+		info:    makeFilterInfo(cwFilterPrio, unix.ETH_P_ALL),
+	}
+	err = execTC(conn, unix.RTM_NEWTFILTER, netlink.Create|netlink.Replace, fmsg, filterData)
+	runtime.KeepAlive(prog) // keep the program fd valid across the syscall
+	if err != nil {
+		if createdQdisc {
+			_ = execTC(conn, unix.RTM_DELQDISC, 0, qmsg, nil) // best-effort rollback of our qdisc
+		}
+		return nil, fmt.Errorf("attach egress bpf filter: %w", err)
+	}
+
+	return &tcLegacyLink{ifindex: ifindex, createdQdisc: createdQdisc, logger: logger}, nil
+}
+
+// tcLegacyLink is the io.Closer returned by attachClsactEgress. Close removes
+// cargowall's egress filter and, if attachClsactEgress created the clsact qdisc,
+// the qdisc as well.
+type tcLegacyLink struct {
+	ifindex      int
+	createdQdisc bool
+	logger       *slog.Logger
+}
+
+// Close detaches the egress filter (and our clsact qdisc, if we created it).
+// It is best-effort: benign races (ENOENT — already gone; ENODEV — interface
+// removed, e.g. netns teardown) are ignored, and other failures are logged
+// rather than returned, matching cargowall's shutdown-defer conventions.
+func (t *tcLegacyLink) Close() error {
+	conn, err := netlink.Dial(unix.NETLINK_ROUTE, nil)
+	if err != nil {
+		return fmt.Errorf("dial netlink: %w", err)
+	}
+	defer conn.Close()
+
+	// Remove exactly our egress filter (matched by parent + priority + handle).
+	fmsg := tcMsg{
+		family:  unix.AF_UNSPEC,
+		ifindex: int32(t.ifindex),
+		handle:  cwFilterHandle,
+		parent:  egressParent,
+		info:    makeFilterInfo(cwFilterPrio, unix.ETH_P_ALL),
+	}
+	if err := execTC(conn, unix.RTM_DELTFILTER, 0, fmsg, nil); err != nil && !isBenignDetachErr(err) {
+		t.logger.Warn("Failed to remove legacy TC egress filter", "ifindex", t.ifindex, "error", err)
+	}
+
+	// Only remove the clsact qdisc if we created it, so we never tear down a
+	// qdisc another tool installed.
+	if t.createdQdisc {
+		qmsg := tcMsg{family: unix.AF_UNSPEC, ifindex: int32(t.ifindex), handle: clsactHandle, parent: clsactParent}
+		if err := execTC(conn, unix.RTM_DELQDISC, 0, qmsg, nil); err != nil && !isBenignDetachErr(err) {
+			t.logger.Warn("Failed to remove clsact qdisc", "ifindex", t.ifindex, "error", err)
+		}
+	}
+	return nil
+}
+
+// isBenignDetachErr reports whether a teardown error means there is nothing left
+// to clean up: the object is already gone (ENOENT) or the interface itself has
+// been removed (ENODEV), in which case the kernel reclaimed the qdisc/filter.
+func isBenignDetachErr(err error) bool {
+	return errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ENODEV)
+}

--- a/pkg/tc/clsact_linux.go
+++ b/pkg/tc/clsact_linux.go
@@ -198,7 +198,8 @@ type tcLegacyLink struct {
 func (t *tcLegacyLink) Close() error {
 	conn, err := netlink.Dial(unix.NETLINK_ROUTE, nil)
 	if err != nil {
-		return fmt.Errorf("dial netlink: %w", err)
+		t.logger.Warn("Failed to dial netlink for legacy TC teardown", "ifindex", t.ifindex, "error", err)
+		return nil
 	}
 	defer conn.Close()
 

--- a/pkg/tc/clsact_test.go
+++ b/pkg/tc/clsact_test.go
@@ -88,6 +88,9 @@ func TestEncodeEgressFilterAttrs(t *testing.T) {
 			kind = ad.String()
 		case unix.TCA_OPTIONS:
 			sawOptions = true
+			// Nested has no error return: it folds both fn's returned nad.Err()
+			// and any nested-decode failure into ad.err, which the ad.Err()
+			// check below surfaces — so a malformed nested attr still fails.
 			ad.Nested(func(nad *netlink.AttributeDecoder) error {
 				for nad.Next() {
 					switch nad.Type() {

--- a/pkg/tc/clsact_test.go
+++ b/pkg/tc/clsact_test.go
@@ -1,0 +1,200 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package tc
+
+import (
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// TestHtons verifies htons produces network (big-endian) byte order on any host.
+func TestHtons(t *testing.T) {
+	var b [2]byte
+	binary.NativeEndian.PutUint16(b[:], htons(0x0102))
+	if b[0] != 0x01 || b[1] != 0x02 {
+		t.Errorf("htons(0x0102) bytes = %#v, want network order {0x01, 0x02}", b)
+	}
+}
+
+// TestMakeFilterInfo verifies the tcmsg info packing: priority in the high 16
+// bits, protocol in network byte order in the low 16 bits. Host-independent.
+func TestMakeFilterInfo(t *testing.T) {
+	info := makeFilterInfo(cwFilterPrio, unix.ETH_P_ALL)
+
+	if got := uint16(info >> 16); got != cwFilterPrio {
+		t.Errorf("priority = %#x, want %#x", got, cwFilterPrio)
+	}
+
+	var low [2]byte
+	binary.NativeEndian.PutUint16(low[:], uint16(info))
+	if got := binary.BigEndian.Uint16(low[:]); got != uint16(unix.ETH_P_ALL) {
+		t.Errorf("protocol = %#x, want %#x (ETH_P_ALL in network order)", got, unix.ETH_P_ALL)
+	}
+}
+
+// TestEncodeEgressFilterAttrs decodes the encoded cls_bpf filter attributes and
+// asserts the direct-action flag is set. This guards the most dangerous failure
+// mode: without TCA_BPF_FLAG_ACT_DIRECT the program's return code is treated as
+// a classid rather than a verdict, so TC_ACT_SHOT would not drop and the
+// firewall would silently fail open.
+func TestEncodeEgressFilterAttrs(t *testing.T) {
+	const fd = 42
+	data, err := encodeEgressFilterAttrs(fd)
+	if err != nil {
+		t.Fatalf("encodeEgressFilterAttrs: %v", err)
+	}
+
+	ad, err := netlink.NewAttributeDecoder(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var (
+		kind       string
+		gotFD      uint32
+		gotName    string
+		gotFlags   uint32
+		sawOptions bool
+	)
+	for ad.Next() {
+		switch ad.Type() {
+		case unix.TCA_KIND:
+			kind = ad.String()
+		case unix.TCA_OPTIONS:
+			sawOptions = true
+			ad.Nested(func(nad *netlink.AttributeDecoder) error {
+				for nad.Next() {
+					switch nad.Type() {
+					case tcaBPFFD:
+						gotFD = nad.Uint32()
+					case tcaBPFName:
+						gotName = nad.String()
+					case tcaBPFFlags:
+						gotFlags = nad.Uint32()
+					}
+				}
+				return nad.Err()
+			})
+		}
+	}
+	if err := ad.Err(); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if kind != "bpf" {
+		t.Errorf("TCA_KIND = %q, want \"bpf\"", kind)
+	}
+	if !sawOptions {
+		t.Error("missing TCA_OPTIONS")
+	}
+	if gotFD != fd {
+		t.Errorf("TCA_BPF_FD = %d, want %d", gotFD, fd)
+	}
+	if gotName != cwFilterName {
+		t.Errorf("TCA_BPF_NAME = %q, want %q", gotName, cwFilterName)
+	}
+	if gotFlags != bpfFlagActDirect {
+		t.Errorf("TCA_BPF_FLAGS = %#x, want %#x (direct-action) — without this the firewall fails open", gotFlags, bpfFlagActDirect)
+	}
+}
+
+// TestAttachClsactEgressIntegration exercises the real netlink round-trip
+// (create clsact qdisc, attach a direct-action bpf filter, then detach) against
+// the loopback interface. It requires root (CAP_NET_ADMIN) so it is skipped in
+// the unprivileged test pass and runs under the sudo lane (see Makefile).
+func TestAttachClsactEgressIntegration(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root (CAP_NET_ADMIN) to manage tc qdiscs/filters")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Fatalf("remove memlock: %v", err)
+	}
+
+	// Minimal SCHED_CLS program returning TC_ACT_OK; enough to attach a filter.
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: ebpf.SchedCLS,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0), // TC_ACT_OK
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		t.Fatalf("load SCHED_CLS program: %v", err)
+	}
+	defer prog.Close()
+
+	lo, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Fatalf("lookup lo: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	closer, err := attachClsactEgress(lo.Index, prog, logger)
+	if err != nil {
+		t.Fatalf("attachClsactEgress: %v", err)
+	}
+	// Safety net in case an assertion below fails before the explicit Close.
+	defer func() { _ = closer.Close() }()
+
+	if out, ok := tcFilterShow(t, "lo"); ok {
+		if !strings.Contains(out, cwFilterName) {
+			t.Errorf("tc filter show did not list %q:\n%s", cwFilterName, out)
+		}
+		if !strings.Contains(out, "direct-action") {
+			t.Errorf("tc filter show missing direct-action:\n%s", out)
+		}
+	}
+
+	if err := closer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if out, ok := tcFilterShow(t, "lo"); ok && strings.Contains(out, cwFilterName) {
+		t.Errorf("filter %q still present after Close:\n%s", cwFilterName, out)
+	}
+}
+
+// tcFilterShow runs `tc filter show dev <ifname> egress` and returns its output.
+// ok is false when the iproute2 `tc` binary is unavailable, in which case the
+// caller should skip the inspection (the attach/detach round-trip itself
+// already validated the netlink path).
+func tcFilterShow(t *testing.T, ifname string) (string, bool) {
+	t.Helper()
+	bin, err := exec.LookPath("tc")
+	if err != nil {
+		return "", false
+	}
+	out, err := exec.Command(bin, "filter", "show", "dev", ifname, "egress").CombinedOutput()
+	if err != nil {
+		t.Logf("tc filter show failed: %v\n%s", err, out)
+		return "", false
+	}
+	return string(out), true
+}


### PR DESCRIPTION
Closes #58 

  ## What & why

  cargowall attached its egress eBPF program with `link.AttachTCX`, which requires the **TCX hook merged in Linux 6.6**. On older kernels the attach failed and cargowall refused to start — even though the classic **`clsact`** attach path (Linux 4.5+) worked there for years. This contradicted
  the documented "5.x or newer" support claim and, in particular, broke **GitLab SaaS shared runners (Linux 5.15)**, where `cargowall start --gitlab-ci` could not attach.

  This PR makes the egress attach **prefer TCX on 6.6+ and transparently fall back to a legacy `clsact` qdisc + direct-action `cls_bpf` filter on 5.8–6.5**, so cargowall works on kernel **5.8+**. (5.8 is the real floor: `bpf/tcbpf.c` uses `BPF_MAP_TYPE_RINGBUF`, which landed in 5.8 — the
  attach mechanism was never the limiter.)

  ## Changes

  - **New `pkg/tc` package** owns the egress attach. `tc.AttachEgress` tries `link.AttachTCX` and, **only** on `ebpf.ErrNotSupported`, falls back to `clsact`; any other error is fatal (fail-closed). It returns an `io.Closer`, so the caller's teardown is mechanism-agnostic. `AttachTC` is
  removed from `pkg/network`.
  - **Hand-rolled netlink clsact** (`pkg/tc/clsact_linux.go`) built on `github.com/mdlayher/netlink` — already a transitive dependency via `cilium/ebpf`, so **no new module tree** is introduced. It creates the clsact qdisc only if absent (libbpf-style ownership: teardown removes the qdisc
  only if we created it) and attaches the program as a **direct-action** filter.
    - ⚠️ Direct-action (`TCA_BPF_FLAG_ACT_DIRECT`) is mandatory: without it `cls_bpf` treats the program's return code as a classid rather than a verdict, so `TC_ACT_SHOT` wouldn't drop — a silent fail-open. It is set and unit-tested.
  - **Kernel floor corrected to 5.8** in `pkg/ebpf/detect.go` (`isKernelSupported` previously accepted any 5.x) plus clearer messaging; README requirements + the CI-mode error strings are updated, and the GitLab section now states SaaS 5.15 attaches via clsact automatically.
  - **No BPF changes** — the same `SCHED_CLS` object attaches via either mechanism (audited: no CO-RE relocations; ringbuf at 5.8 is the newest feature it uses).
  - Bumps `cargowall-action` to **v1.3.0** across the workflows + README, and adds `iproute2` to the CI test job so the integration test's `tc filter show` assertions run in CI.

  ## Testing

  - **Unit (kernel-independent, runs in CI):** `isKernelSupported` table (4.19/5.4/5.7 rejected; 5.8/5.15/6.6 accepted); `htons`/`makeFilterInfo` byte-order packing; `encodeEgressFilterAttrs` decodes the filter attrs and asserts the direct-action flag (the fail-open guard).
  - **Root-gated integration** (`./pkg/tc` added to the sudo test lane): attaches a minimal `SCHED_CLS` program to `lo` through the clsact path, verifies a `direct-action` filter via `tc filter show`, then detaches and confirms cleanup.
  - Verified locally: `go build` / `go vet` / `staticcheck` / `gofumpt` clean (`GOOS=linux`); full `./pkg/...` suite green in a privileged container with `iproute2`.