### PR TITLE
#62 transparent CNAME support

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Useful flags (most available as env vars — see `cargowall start --help`):
 | `--gitlab-ci` | `CARGOWALL_GITLAB_CI` | GitLab CI preset (same plumbing, GitLab service host auto-allow instead) |
 | `--dns-redirect-iptables` | `CARGOWALL_DNS_REDIRECT_IPTABLES` | iptables DNAT outbound :53 → `127.0.0.1:53` |
 | `--docker-dns-interception` | `CARGOWALL_DOCKER_DNS_INTERCEPTION` | Listen on the Docker bridge IP and rewrite `/etc/docker/daemon.json` |
-| `--dns-query-filtering` | `CARGOWALL_DNS_QUERY_FILTERING` | Filter DNS queries against the policy (blocks DNS tunneling) |
+| `--dns-query-filtering` | `CARGOWALL_DNS_QUERY_FILTERING` | Filter DNS queries against the policy (blocks DNS tunneling). CNAME targets of allowed hosts are auto-permitted, so CNAME-chasing clients aren't refused |
 | `--prepopulate-dns-cache` | `CARGOWALL_PREPOPULATE_DNS_CACHE` | Seed the BPF allowlist from systemd-resolved + existing TCP connections |
 | `--auto-allow-cloud-metadata` | `CARGOWALL_AUTO_ALLOW_CLOUD_METADATA` | Allow IMDS at `169.254.169.254`; detects AWS / Azure / GCP via DMI (override with `CARGOWALL_CLOUD_PROVIDER=aws\|azure\|gcp`, case-insensitive; unknown values are ignored and detection falls through to DMI / wireserver signals) and adds provider-specific allows: Azure wireserver + infra hostnames + `.internal.cloudapp.net`, AWS `.compute.internal` + `.ec2.internal`, GCP `.google.internal` |
 | `--auto-allow-github-hosts` | `CARGOWALL_AUTO_ALLOW_GITHUB_HOSTS` | Allow GitHub service hosts + `ACTIONS_*` runtime URL discovery |

--- a/design.md
+++ b/design.md
@@ -351,7 +351,7 @@ sequenceDiagram
 - Primary listen address `127.0.0.1:53`, with additional addresses (e.g., Docker bridge IP) via `AddListenAddr()`
 - Configurable upstream DNS (e.g., `10.96.0.10:53` for Kubernetes)
 - LRU cache (10,000 entries) with per-entry TTL from DNS response minimum TTL
-- DNS query filtering (`EnableQueryFiltering`) — blocks queries for non-allowed domains; always allows reverse DNS (`in-addr.arpa`, `ip6.arpa`)
+- DNS query filtering (`EnableQueryFiltering`) — blocks queries for non-allowed domains; always allows reverse DNS (`in-addr.arpa`, `ip6.arpa`). CNAME targets seen in a rule-allowed response are learned (TTL-bounded, 10,000-entry LRU) and permitted for later direct queries, so CNAME-chasing clients resolving an allowed host's chain (e.g. an Akamai edge name) aren't refused; explicit deny rules still win. Learning is scoped to rule-allowed responses, so the only widening of the DNS-tunneling surface is which CNAME-target *names* may be queried — within the trust already extended to the allowed host's upstream chain (IP enforcement already follows that chain regardless)
 - `ApplyRulesToTrackedHostnames()` — re-evaluates all accumulated IPs against current config after rule changes
 - Rule conflict detection: checks CIDR vs hostname action conflicts via `CheckIPRuleConflict()`; deny wins
 - Kubernetes search domain stripping (`.default.svc.cluster.local`, `.svc.cluster.local`, `.cluster.local`)

--- a/pkg/dns/lru_test.go
+++ b/pkg/dns/lru_test.go
@@ -25,6 +25,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// peekExpiry returns the expiry recorded for key and whether the key is
+// present, without touching LRU order or applying lazy expiration. A zero
+// expiry means the entry never expires. Test-only introspection so tests can
+// assert the stored TTL (the public API only exposes presence via Get).
+func (c *lruCache[K, V]) peekExpiry(key K) (time.Time, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem, ok := c.items[key]
+	if !ok {
+		return time.Time{}, false
+	}
+	return elem.Value.(*lruEntry[K, V]).expiry, true
+}
+
 // Basic round-trip: Put → Get returns the stored value.
 func TestLRUCache_Basic(t *testing.T) {
 	c := newLRUCache[string, int](10)

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -432,17 +432,17 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// A/AAAA in the same message) still register their targets. Only
 		// rule-allowed responses qualify: a single forwarded response already
 		// carries every hop of the chain, so we never learn transitively from
-		// derived-allowed queries — that keeps the surface bounded. ttl is the
-		// response-wide min from extractIPsFromResponse, a conservative expiry
-		// that tracks the shortest-lived record. A target whose entry expires
-		// before its origin's dnsCache entry just gets re-REFUSED until the
-		// next origin query re-learns it — self-healing and TTL-bounded.
-		if s.filterQueries && verdict.HasAllow() {
+		// derived-allowed queries — that keeps the surface bounded. A target
+		// whose entry expires before its origin's dnsCache entry just gets
+		// re-REFUSED until the next origin query re-learns it — self-healing
+		// and TTL-bounded.
+		if s.filterQueries && verdict.HasAllow() && s.cnameAllowed != nil {
+			cnameTTL := time.Duration(derivedCNAMETTL(ttl)) * time.Second
 			for _, ans := range resp.Answer {
 				if cn, ok := ans.(*dns.CNAME); ok {
 					target := strings.ToLower(strings.TrimSuffix(cn.Target, "."))
 					if target != "" {
-						s.cnameAllowed.Put(target, true, time.Duration(ttl)*time.Second)
+						s.cnameAllowed.Put(target, true, cnameTTL)
 					}
 				}
 			}
@@ -519,6 +519,19 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	if err := w.WriteMsg(resp); err != nil {
 		s.logger.Error("Failed to write DNS response", "error", err)
 	}
+}
+
+// derivedCNAMETTL floors a response TTL for the derived CNAME-allow cache.
+// extractIPsFromResponse returns the literal response-wide min, which can be 0
+// (some CDNs/load-balancers return TTL 0 to defeat caching). lruCache treats a
+// 0 duration as "never expires", so a literal 0 would pin the derived allow
+// indefinitely — the opposite of the TTL-bounded guarantee. Floor it to the
+// same default the dnsCache path uses (300s / 5 min).
+func derivedCNAMETTL(ttl uint32) uint32 {
+	if ttl == 0 {
+		return 300
+	}
+	return ttl
 }
 
 // extractIPsFromResponse extracts IPv4 and IPv6 addresses from msg.Answer

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -540,14 +540,19 @@ type cnameLink struct {
 // lifetime rather than the response-wide minimum.
 func cnameChainTargets(qname string, answers []dns.RR) []cnameLink {
 	// Index CNAMEs by lowercased owner; first record for an owner wins so a
-	// duplicate owner can't redirect the walk.
-	byOwner := make(map[string]*dns.CNAME, len(answers))
+	// duplicate owner can't redirect the walk. Allocated lazily so the common
+	// CNAME-free response (e.g. a round-robin A answer) costs no map — a nil
+	// map read below is safe and simply ends the walk.
+	var byOwner map[string]*dns.CNAME
 	for _, ans := range answers {
 		cn, ok := ans.(*dns.CNAME)
 		if !ok {
 			continue
 		}
 		owner := strings.ToLower(strings.TrimSuffix(cn.Header().Name, "."))
+		if byOwner == nil {
+			byOwner = make(map[string]*dns.CNAME, len(answers))
+		}
 		if _, exists := byOwner[owner]; !exists {
 			byOwner[owner] = cn
 		}

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -432,19 +432,21 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// A/AAAA in the same message) still register their targets. Only
 		// rule-allowed responses qualify: a single forwarded response already
 		// carries every hop of the chain, so we never learn transitively from
-		// derived-allowed queries — that keeps the surface bounded. A target
-		// whose entry expires before its origin's dnsCache entry just gets
-		// re-REFUSED until the next origin query re-learns it — self-healing
-		// and TTL-bounded.
+		// derived-allowed queries — that keeps the surface bounded.
+		//
+		// cnameChainTargets follows the chain from the query name only, so
+		// unrelated CNAME records in the same response (a misbehaving or
+		// spoofed authoritative server for an allowed domain) are ignored
+		// instead of registering arbitrary names. Each target is learned for
+		// its own CNAME TTL (not the response-wide min, which would shorten it
+		// to the final address record's TTL), floored by derivedCNAMETTL. A
+		// target whose entry expires before its origin's dnsCache entry just
+		// gets re-REFUSED until the next origin query re-learns it —
+		// self-healing and TTL-bounded.
 		if s.filterQueries && verdict.HasAllow() && s.cnameAllowed != nil {
-			cnameTTL := time.Duration(derivedCNAMETTL(ttl)) * time.Second
-			for _, ans := range resp.Answer {
-				if cn, ok := ans.(*dns.CNAME); ok {
-					target := strings.ToLower(strings.TrimSuffix(cn.Target, "."))
-					if target != "" {
-						s.cnameAllowed.Put(target, true, cnameTTL)
-					}
-				}
+			for _, link := range cnameChainTargets(canonicalHostname, resp.Answer) {
+				ttl := time.Duration(derivedCNAMETTL(link.ttl)) * time.Second
+				s.cnameAllowed.Put(link.target, true, ttl)
 			}
 		}
 
@@ -521,12 +523,60 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	}
 }
 
-// derivedCNAMETTL floors a response TTL for the derived CNAME-allow cache.
-// extractIPsFromResponse returns the literal response-wide min, which can be 0
-// (some CDNs/load-balancers return TTL 0 to defeat caching). lruCache treats a
-// 0 duration as "never expires", so a literal 0 would pin the derived allow
-// indefinitely — the opposite of the TTL-bounded guarantee. Floor it to the
-// same default the dnsCache path uses (300s / 5 min).
+// cnameLink is one hop of a CNAME chain: the target name (lowercased, no
+// trailing dot) and the TTL of the CNAME record that points to it.
+type cnameLink struct {
+	target string
+	ttl    uint32
+}
+
+// cnameChainTargets walks the CNAME chain in answers starting from qname
+// (which must already be lowercased and trailing-dot-trimmed) and returns the
+// ordered targets actually reachable from qname. CNAME records whose owner is
+// not on the chain — unrelated or attacker-injected records in an otherwise
+// rule-allowed response — are ignored, so they can't register arbitrary names
+// as queryable. A visited set bounds malicious loops (A→B→A). Each target
+// carries its own CNAME record's TTL so the caller can expire it on the hop's
+// lifetime rather than the response-wide minimum.
+func cnameChainTargets(qname string, answers []dns.RR) []cnameLink {
+	// Index CNAMEs by lowercased owner; first record for an owner wins so a
+	// duplicate owner can't redirect the walk.
+	byOwner := make(map[string]*dns.CNAME, len(answers))
+	for _, ans := range answers {
+		cn, ok := ans.(*dns.CNAME)
+		if !ok {
+			continue
+		}
+		owner := strings.ToLower(strings.TrimSuffix(cn.Header().Name, "."))
+		if _, exists := byOwner[owner]; !exists {
+			byOwner[owner] = cn
+		}
+	}
+
+	var chain []cnameLink
+	visited := make(map[string]bool)
+	for cur := qname; ; {
+		cn, ok := byOwner[cur]
+		if !ok {
+			break
+		}
+		target := strings.ToLower(strings.TrimSuffix(cn.Target, "."))
+		if target == "" || visited[target] {
+			break
+		}
+		visited[target] = true
+		chain = append(chain, cnameLink{target: target, ttl: cn.Header().Ttl})
+		cur = target
+	}
+	return chain
+}
+
+// derivedCNAMETTL floors a CNAME record's TTL for the derived CNAME-allow
+// cache. A record's TTL can be 0 (some CDNs/load-balancers return TTL 0 to
+// defeat caching), and lruCache treats a 0 duration as "never expires", so a
+// literal 0 would pin the derived allow indefinitely — the opposite of the
+// TTL-bounded guarantee. Floor it to the same default the dnsCache path uses
+// (300s / 5 min).
 func derivedCNAMETTL(ttl uint32) uint32 {
 	if ttl == 0 {
 		return 300

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -59,6 +59,12 @@ type Server struct {
 	// DNS response cache (LRU with per-entry TTL)
 	dnsCache *lruCache[string, *dnsCacheEntry]
 
+	// CNAME targets learned from rule-allowed responses (LRU with per-entry
+	// TTL). Consulted only by the query filter: a separate query for a CNAME
+	// target of an allowed host is permitted instead of REFUSED. Does not
+	// affect IP enforcement, which already follows CNAME chains.
+	cnameAllowed *lruCache[string, bool]
+
 	// Audit logger for DNS events
 	auditLogger *events.AuditLogger
 }
@@ -88,8 +94,9 @@ func NewServer(cfg *config.Manager, fw firewall.Firewall, upstream, listenAddr s
 				},
 			},
 		},
-		hostnameIPs: make(map[string]map[string]bool),
-		dnsCache:    newLRUCache[string, *dnsCacheEntry](10000),
+		hostnameIPs:  make(map[string]map[string]bool),
+		dnsCache:     newLRUCache[string, *dnsCacheEntry](10000),
+		cnameAllowed: newLRUCache[string, bool](10000),
 	}
 }
 
@@ -130,10 +137,15 @@ func (s *Server) EnableQueryFiltering(enable bool) {
 //     rule fires — the firewall layer enforces per-port deny separately.
 //     A pure deny verdict (no allow) blocks the query. A deny rule for
 //     "blocked" still blocks "blocked.compute.internal".
-//  4. Search-domain bypass: full form ends in a configured suffix → allow.
+//  4. Derived CNAME-target allow: the name was learned as a CNAME target of
+//     a rule-allowed response → allow. This lets CNAME-chasing clients query
+//     the target directly (e.g. an Akamai edge name an allowed host CNAMEs
+//     to) instead of being REFUSED. Checked AFTER the deny rule above, so an
+//     explicit deny on the target still wins.
+//  5. Search-domain bypass: full form ends in a configured suffix → allow.
 //     This is the "let cloud-internal names resolve when no hostname rule
 //     covers them" path; traffic is still governed by hostname/CIDR rules.
-//  5. Default action.
+//  6. Default action.
 func (s *Server) isQueryAllowed(domain string, qtype uint16) bool {
 	if !s.filterQueries {
 		return true
@@ -154,6 +166,16 @@ func (s *Server) isQueryAllowed(domain string, qtype uint16) bool {
 	}
 	if verdict.HasDeny() {
 		return false
+	}
+
+	// Derived CNAME-target allow. Populated in handleDNSQuery when a
+	// rule-allowed response carries CNAME records (see s.cnameAllowed). The
+	// nil guard keeps Server literals constructed without NewServer (some
+	// tests) working. Checked after the deny rule above so a deny still wins.
+	if s.cnameAllowed != nil {
+		if _, ok := s.cnameAllowed.Get(strings.ToLower(domain)); ok {
+			return true
+		}
 	}
 
 	// No explicit rule — try the search-domain bypass. HasSearchDomainSuffix
@@ -390,24 +412,48 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// Extract IPs and TTLs from response
 		ips, ttl := s.extractIPsFromResponse(resp)
 
+		// Lowercase once for all canonical-form operations below; keep
+		// fullHostname for log attribution so wire-case is preserved in
+		// audit/debug output.
+		canonicalHostname := strings.ToLower(fullHostname)
+
+		// One MatchHostnameRule call per resolution — it internally evaluates
+		// both the full and search-domain-stripped forms and folds the result
+		// into a single HostnameVerdict. Calling it once per form here would be
+		// redundant and unsafe: the resulting BPF map updates could be applied
+		// in non-deterministic map-iteration order, letting the wrong form's
+		// action win the last-write race.
+		verdict := s.config.MatchHostnameRule(canonicalHostname)
+
+		// Learn CNAME targets from rule-allowed responses so CNAME-chasing
+		// clients can query them directly under query filtering instead of
+		// being REFUSED (consulted by isQueryAllowed via s.cnameAllowed). Done
+		// outside the len(ips)>0 guard below so CNAME-only responses (no
+		// A/AAAA in the same message) still register their targets. Only
+		// rule-allowed responses qualify: a single forwarded response already
+		// carries every hop of the chain, so we never learn transitively from
+		// derived-allowed queries — that keeps the surface bounded. ttl is the
+		// response-wide min from extractIPsFromResponse, a conservative expiry
+		// that tracks the shortest-lived record. A target whose entry expires
+		// before its origin's dnsCache entry just gets re-REFUSED until the
+		// next origin query re-learns it — self-healing and TTL-bounded.
+		if s.filterQueries && verdict.HasAllow() {
+			for _, ans := range resp.Answer {
+				if cn, ok := ans.(*dns.CNAME); ok {
+					target := strings.ToLower(strings.TrimSuffix(cn.Target, "."))
+					if target != "" {
+						s.cnameAllowed.Put(target, true, time.Duration(ttl)*time.Second)
+					}
+				}
+			}
+		}
+
 		if len(ips) > 0 {
 			s.logger.Debug("DNS resolution intercepted",
 				"hostname", fullHostname,
 				"ip_count", len(ips),
 				"ttl", ttl)
 
-			// Lowercase once for all canonical-form operations below; keep
-			// fullHostname for log attribution so wire-case is preserved
-			// in audit/debug output.
-			canonicalHostname := strings.ToLower(fullHostname)
-
-			// One MatchHostnameRule call per resolution — it internally
-			// evaluates both the full and search-domain-stripped forms and
-			// folds the result into a single HostnameVerdict. Calling it once
-			// per form here would be redundant and unsafe: the resulting BPF
-			// map updates could be applied in non-deterministic map-iteration
-			// order, letting the wrong form's action win the last-write race.
-			verdict := s.config.MatchHostnameRule(canonicalHostname)
 			// User-configured search-domain suffixes only — Kubernetes
 			// suffixes are strip-only, not bypass, and live separately in
 			// the config manager (see kubernetesSearchDomains).

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1853,8 +1853,80 @@ func TestHandleDNSQuery_CNAMEZeroTTLStillLearns(t *testing.T) {
 	server.handleDNSQuery(w, query)
 	w.AssertExpectations(t)
 
-	_, ok := server.cnameAllowed.Get("a441.dscd.akamai.net")
-	assert.True(t, ok, "TTL-0 response must still learn its CNAME target")
+	// Assert the stored expiry, not just presence: a regression that Put the
+	// raw 0 TTL would store a never-expiring entry (zero expiry), which Get
+	// alone can't distinguish from a bounded one. derivedCNAMETTL floors 0 to
+	// 300s, so the entry must carry a non-zero expiry ~300s out.
+	exp, ok := server.cnameAllowed.peekExpiry("a441.dscd.akamai.net")
+	require.True(t, ok, "TTL-0 response must still learn its CNAME target")
+	require.False(t, exp.IsZero(), "TTL-0 must be floored, not stored as never-expires")
+	remaining := time.Until(exp)
+	assert.Greater(t, remaining, 290*time.Second, "expiry should be floored to ~300s")
+	assert.LessOrEqual(t, remaining, 300*time.Second)
+}
+
+// Each CNAME target must be learned for its OWN hop's TTL, not the response-wide
+// minimum (which would fold in the final address record's shorter TTL). This
+// asserts the end-to-end wiring: handleDNSQuery → cnameChainTargets per-hop ttl
+// → derivedCNAMETTL → cnameAllowed.Put.
+func TestHandleDNSQuery_CNAMEPerHopTTLApplied(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	const origin = "builds.dotnet.microsoft.com."
+	cn := func(owner, target string, ttl uint32) *dns.CNAME {
+		return &dns.CNAME{
+			Hdr:    dns.RR_Header{Name: dns.Fqdn(owner), Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: ttl},
+			Target: dns.Fqdn(target),
+		}
+	}
+	// origin --(120s)--> hop1 --(45s)--> a441, with a short-TTL A record (10s).
+	// If the learn path used the response-wide min, both targets would expire
+	// in ~10s; per-hop TTLs keep them at 120s and 45s.
+	resp := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: 7000, Response: true, Rcode: dns.RcodeSuccess},
+		Question: []dns.Question{{Name: origin, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+		Answer: []dns.RR{
+			cn(origin, "hop1.example.net", 120),
+			cn("hop1.example.net", "a441.dscd.akamai.net", 45),
+			&dns.A{
+				Hdr: dns.RR_Header{Name: "a441.dscd.akamai.net.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 10},
+				A:   net.ParseIP("23.56.109.139"),
+			},
+		},
+	}
+	seedCachedResponse(server, origin, resp)
+
+	mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil).Once()
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 7001
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	for _, tc := range []struct {
+		name   string
+		ttl    time.Duration
+		lowest time.Duration
+	}{
+		{"hop1.example.net", 120 * time.Second, 110 * time.Second},
+		{"a441.dscd.akamai.net", 45 * time.Second, 40 * time.Second},
+	} {
+		exp, ok := server.cnameAllowed.peekExpiry(tc.name)
+		require.True(t, ok, "%s should be learned", tc.name)
+		remaining := time.Until(exp)
+		assert.Greater(t, remaining, tc.lowest, "%s expiry should reflect its own CNAME TTL, not the response min", tc.name)
+		assert.LessOrEqual(t, remaining, tc.ttl, "%s expiry should not exceed its own CNAME TTL", tc.name)
+	}
 }
 
 // cnameChainTargets must follow only the chain rooted at the query name, carry

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1814,6 +1814,49 @@ func TestHandleDNSQuery_CNAMELearnedInAuditMode(t *testing.T) {
 	assert.True(t, ok, "CNAME learning must work in audit mode too")
 }
 
+// derivedCNAMETTL floors a 0 TTL so the derived allow can never be stored as
+// a never-expiring lruCache entry; non-zero TTLs pass through unchanged.
+func TestDerivedCNAMETTL(t *testing.T) {
+	assert.Equal(t, uint32(300), derivedCNAMETTL(0), "TTL 0 must be floored, not stored as never-expires")
+	assert.Equal(t, uint32(1), derivedCNAMETTL(1))
+	assert.Equal(t, uint32(20), derivedCNAMETTL(20))
+	assert.Equal(t, uint32(86400), derivedCNAMETTL(86400))
+}
+
+// End-to-end guard for the TTL-0 case (some CDNs return TTL 0 to defeat
+// caching): the target is still learned, and via derivedCNAMETTL it is stored
+// with a bounded expiry rather than a permanent entry.
+func TestHandleDNSQuery_CNAMEZeroTTLStillLearns(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	const origin = "builds.dotnet.microsoft.com."
+	resp := makeCNAMEResponse(origin, []string{"a441.dscd.akamai.net"}, "23.56.109.139")
+	for _, ans := range resp.Answer { // force every RR to TTL 0
+		ans.Header().Ttl = 0
+	}
+	seedCachedResponse(server, origin, resp)
+
+	mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil).Once()
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 6006
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	_, ok := server.cnameAllowed.Get("a441.dscd.akamai.net")
+	assert.True(t, ok, "TTL-0 response must still learn its CNAME target")
+}
+
 // Counterpoint to the above: when a rule matches the stripped form (the K8s
 // or short-name pattern), per-host tracking SHOULD happen and the firewall
 // SHOULD be updated.

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1857,6 +1857,110 @@ func TestHandleDNSQuery_CNAMEZeroTTLStillLearns(t *testing.T) {
 	assert.True(t, ok, "TTL-0 response must still learn its CNAME target")
 }
 
+// cnameChainTargets must follow only the chain rooted at the query name, carry
+// each hop's own TTL, ignore unrelated/injected CNAME records, and terminate
+// on loops.
+func TestCnameChainTargets(t *testing.T) {
+	cname := func(owner, target string, ttl uint32) *dns.CNAME {
+		return &dns.CNAME{
+			Hdr:    dns.RR_Header{Name: dns.Fqdn(owner), Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: ttl},
+			Target: dns.Fqdn(target),
+		}
+	}
+
+	t.Run("follows chain from query name with per-hop TTLs", func(t *testing.T) {
+		answers := []dns.RR{
+			cname("builds.dotnet.microsoft.com", "dotnetcli.trafficmanager.net", 100),
+			cname("dotnetcli.trafficmanager.net", "a441.dscd.akamai.net", 50),
+			&dns.A{
+				Hdr: dns.RR_Header{Name: "a441.dscd.akamai.net.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 20},
+				A:   net.ParseIP("23.56.109.139"),
+			},
+		}
+		got := cnameChainTargets("builds.dotnet.microsoft.com", answers)
+		require.Len(t, got, 2)
+		// TTLs are the CNAMEs' own (100, 50), not the address record's 20.
+		assert.Equal(t, cnameLink{target: "dotnetcli.trafficmanager.net", ttl: 100}, got[0])
+		assert.Equal(t, cnameLink{target: "a441.dscd.akamai.net", ttl: 50}, got[1])
+	})
+
+	t.Run("ignores CNAME records not on the chain", func(t *testing.T) {
+		answers := []dns.RR{
+			cname("builds.dotnet.microsoft.com", "a441.dscd.akamai.net", 100),
+			cname("evil.example.com", "attacker.example.net", 100), // owner off-chain
+		}
+		got := cnameChainTargets("builds.dotnet.microsoft.com", answers)
+		require.Len(t, got, 1)
+		assert.Equal(t, "a441.dscd.akamai.net", got[0].target)
+	})
+
+	t.Run("case-insensitive owner matching", func(t *testing.T) {
+		answers := []dns.RR{cname("Builds.Dotnet.Microsoft.COM", "A441.DSCD.Akamai.NET", 30)}
+		got := cnameChainTargets("builds.dotnet.microsoft.com", answers)
+		require.Len(t, got, 1)
+		assert.Equal(t, cnameLink{target: "a441.dscd.akamai.net", ttl: 30}, got[0])
+	})
+
+	t.Run("terminates on a loop", func(t *testing.T) {
+		answers := []dns.RR{
+			cname("a.example.com", "b.example.com", 100),
+			cname("b.example.com", "a.example.com", 100), // loops back
+		}
+		got := cnameChainTargets("a.example.com", answers)
+		require.Len(t, got, 2) // a→b, b→a, then a revisited → stop
+		assert.Equal(t, "b.example.com", got[0].target)
+		assert.Equal(t, "a.example.com", got[1].target)
+	})
+
+	t.Run("no CNAME for query name returns nil", func(t *testing.T) {
+		answers := []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: "builds.dotnet.microsoft.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 20},
+				A:   net.ParseIP("23.56.109.139"),
+			},
+		}
+		assert.Empty(t, cnameChainTargets("builds.dotnet.microsoft.com", answers))
+	})
+}
+
+// An unrelated CNAME record in an otherwise rule-allowed response (a spoofed or
+// misbehaving authoritative server) must NOT register its target — only names
+// on the chain rooted at the query name are learned.
+func TestHandleDNSQuery_CNAMEUnrelatedRecordNotLearned(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	const origin = "builds.dotnet.microsoft.com."
+	resp := makeCNAMEResponse(origin, []string{"a441.dscd.akamai.net"}, "23.56.109.139")
+	// Inject an off-chain CNAME, as a spoofed/misbehaving server might.
+	resp.Answer = append(resp.Answer, &dns.CNAME{
+		Hdr:    dns.RR_Header{Name: "evil.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: "attacker.example.net.",
+	})
+	seedCachedResponse(server, origin, resp)
+
+	mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil).Once()
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 6007
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	_, ok := server.cnameAllowed.Get("a441.dscd.akamai.net")
+	assert.True(t, ok, "on-chain target should be learned")
+	_, ok = server.cnameAllowed.Get("attacker.example.net")
+	assert.False(t, ok, "unrelated CNAME target must not be learned")
+}
+
 // Counterpoint to the above: when a rule matches the stripped form (the K8s
 // or short-name pattern), per-host tracking SHOULD happen and the firewall
 // SHOULD be updated.

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -1309,6 +1310,80 @@ func TestIsQueryAllowed_SearchDomainBypass(t *testing.T) {
 	}
 }
 
+// TestIsQueryAllowed_CNAMEDerived covers the derived CNAME-target allow path:
+// a name learned as a CNAME target of a rule-allowed response is permitted
+// under query filtering, but an explicit deny still wins and unknown/expired
+// targets are refused.
+func TestIsQueryAllowed_CNAMEDerived(t *testing.T) {
+	tests := []struct {
+		name       string
+		rules      []config.Rule
+		derived    string        // target to pre-seed into cnameAllowed (lowercased on Put)
+		derivedTTL time.Duration // 0 → never expires
+		domain     string
+		expected   bool
+	}{
+		{
+			name:     "derived target is allowed under deny-by-default",
+			derived:  "a441.dscd.akamai.net",
+			domain:   "a441.dscd.akamai.net",
+			expected: true,
+		},
+		{
+			// An explicit deny rule on the target must beat the derived allow —
+			// the deny check in isQueryAllowed precedes the cnameAllowed lookup.
+			name: "explicit deny rule wins over derived allow",
+			rules: []config.Rule{
+				{Type: config.RuleTypeHostname, Value: "a441.dscd.akamai.net", Action: config.ActionDeny},
+			},
+			derived:  "a441.dscd.akamai.net",
+			domain:   "a441.dscd.akamai.net",
+			expected: false,
+		},
+		{
+			name:     "target never learned is refused",
+			derived:  "a441.dscd.akamai.net",
+			domain:   "other.akamai.net",
+			expected: false,
+		},
+		{
+			// DNS names are case-insensitive: Put lowercases, Get must too.
+			name:     "case-insensitive lookup",
+			derived:  "a441.dscd.akamai.net",
+			domain:   "A441.DSCD.Akamai.NET",
+			expected: true,
+		},
+		{
+			name:       "expired derived entry is refused",
+			derived:    "a441.dscd.akamai.net",
+			derivedTTL: time.Nanosecond,
+			domain:     "a441.dscd.akamai.net",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfigManager()
+			require.NoError(t, cfg.LoadConfigFromRules(tt.rules, config.ActionDeny))
+
+			server := &Server{
+				config:        cfg,
+				filterQueries: true,
+				logger:        slog.Default(),
+				cnameAllowed:  newLRUCache[string, bool](10000),
+			}
+			server.cnameAllowed.Put(strings.ToLower(tt.derived), true, tt.derivedTTL)
+			if tt.derivedTTL == time.Nanosecond {
+				time.Sleep(time.Millisecond) // let the entry lazily expire
+			}
+
+			got := server.isQueryAllowed(tt.domain, dns.TypeA)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // handleDNSQuery integration tests
 // ---------------------------------------------------------------------------
@@ -1317,13 +1392,14 @@ func TestIsQueryAllowed_SearchDomainBypass(t *testing.T) {
 func newTestServer(t *testing.T, cfg *config.Manager, fw firewall.Firewall) *Server {
 	t.Helper()
 	return &Server{
-		config:      cfg,
-		firewall:    fw,
-		logger:      slog.Default(),
-		upstream:    "8.8.8.8:53",
-		client:      &dns.Client{Timeout: 5 * time.Second},
-		hostnameIPs: make(map[string]map[string]bool),
-		dnsCache:    newLRUCache[string, *dnsCacheEntry](10000),
+		config:       cfg,
+		firewall:     fw,
+		logger:       slog.Default(),
+		upstream:     "8.8.8.8:53",
+		client:       &dns.Client{Timeout: 5 * time.Second},
+		hostnameIPs:  make(map[string]map[string]bool),
+		dnsCache:     newLRUCache[string, *dnsCacheEntry](10000),
+		cnameAllowed: newLRUCache[string, bool](10000),
 	}
 }
 
@@ -1522,6 +1598,220 @@ func TestHandleDNSQuery_BypassOnlySkipsHostnameTracking(t *testing.T) {
 	// No firewall AddIP should have been called (no matching rule);
 	// firewall.NewMockFirewall(t) will fail the test if any unexpected call
 	// happened, so this is an implicit assertion.
+}
+
+// makeCNAMEResponse builds a successful response for qname that CNAME-chains
+// through targets (in order) and, if finalIP is non-empty, ends in an A record
+// for finalIP attached to the last target. An empty finalIP yields a
+// CNAME-only response (no address record in the same message).
+func makeCNAMEResponse(qname string, targets []string, finalIP string) *dns.Msg {
+	msg := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: 9999, Response: true, Rcode: dns.RcodeSuccess},
+		Question: []dns.Question{{Name: qname, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+	}
+	owner := qname
+	for _, target := range targets {
+		fqdn := dns.Fqdn(target)
+		msg.Answer = append(msg.Answer, &dns.CNAME{
+			Hdr:    dns.RR_Header{Name: owner, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+			Target: fqdn,
+		})
+		owner = fqdn
+	}
+	if finalIP != "" {
+		msg.Answer = append(msg.Answer, &dns.A{
+			Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+			A:   net.ParseIP(finalIP),
+		})
+	}
+	return msg
+}
+
+// seedCachedResponse stores resp in the DNS cache under qname/A so a
+// subsequent handleDNSQuery is served from cache (no upstream call).
+func seedCachedResponse(server *Server, qname string, resp *dns.Msg) {
+	cacheKey := server.generateCacheKey(&dns.Msg{
+		Question: []dns.Question{{Name: qname, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+	})
+	server.dnsCache.Put(cacheKey, &dnsCacheEntry{msg: resp.Copy()}, 5*time.Minute)
+}
+
+// A rule-allowed response that CNAME-chains to other names makes those targets
+// directly queryable under query filtering, so CNAME-chasing clients aren't
+// REFUSED when they look up the target themselves.
+func TestHandleDNSQuery_CNAMELearnedFromAllowedResponse(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	const origin = "builds.dotnet.microsoft.com."
+	resp := makeCNAMEResponse(origin,
+		[]string{"dotnetcli.trafficmanager.net", "a441.dscd.akamai.net"},
+		"23.56.109.139")
+	seedCachedResponse(server, origin, resp)
+
+	// The final A record is allow-listed under the origin's rule (IP path).
+	mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil).Once()
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 6001
+
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	// Every CNAME target in the chain is now queryable directly, even though
+	// no rule names them.
+	for _, target := range []string{"dotnetcli.trafficmanager.net", "a441.dscd.akamai.net"} {
+		_, ok := server.cnameAllowed.Get(target)
+		assert.True(t, ok, "CNAME target %q should be learned", target)
+		assert.True(t, server.isQueryAllowed(target, dns.TypeA),
+			"direct query for CNAME target %q should be allowed", target)
+	}
+}
+
+// A CNAME-only response (no address record in the same message) must still
+// register its target — this is the case CNAME-chasing clients hit when a
+// server answers one hop at a time.
+func TestHandleDNSQuery_CNAMEOnlyResponseStillLearns(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "allowed.example.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	const origin = "allowed.example.com."
+	resp := makeCNAMEResponse(origin, []string{"edge.cdn.example.net"}, "") // no A record
+	seedCachedResponse(server, origin, resp)
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 6002
+
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	// No A record means no firewall call, but the target must still be learned.
+	_, ok := server.cnameAllowed.Get("edge.cdn.example.net")
+	assert.True(t, ok, "CNAME-only response must still learn its target")
+}
+
+// A name allowed only by the search-domain bypass (no matching rule) must NOT
+// contribute its CNAME targets — learning is scoped to rule-allowed responses.
+func TestHandleDNSQuery_CNAMENotLearnedFromBypass(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules(nil, config.ActionDeny))
+	cfg.AddSearchDomains([]string{".compute.internal"}, slog.Default())
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	const origin = "ip-10-0-0-5.us-west-2.compute.internal."
+	resp := makeCNAMEResponse(origin, []string{"edge.cdn.example.net"}, "10.0.0.5")
+	seedCachedResponse(server, origin, resp)
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 6003
+
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	_, ok := server.cnameAllowed.Get("edge.cdn.example.net")
+	assert.False(t, ok, "bypass-only resolution must not learn CNAME targets")
+}
+
+// The response block runs for cache hits too, so a derived target that expired
+// ahead of its origin's cache entry is re-learned on the next origin query.
+func TestHandleDNSQuery_CNAMERefreshedOnCacheHit(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	const origin = "builds.dotnet.microsoft.com."
+	resp := makeCNAMEResponse(origin, []string{"a441.dscd.akamai.net"}, "23.56.109.139")
+	seedCachedResponse(server, origin, resp)
+
+	// Deduped by the firewall after the first add; allow any number of calls.
+	mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil)
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 6004
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil)
+
+	server.handleDNSQuery(w, query)
+	_, ok := server.cnameAllowed.Get("a441.dscd.akamai.net")
+	require.True(t, ok)
+
+	// Simulate the derived entry expiring before the dnsCache entry.
+	server.cnameAllowed.Delete("a441.dscd.akamai.net")
+	_, ok = server.cnameAllowed.Get("a441.dscd.akamai.net")
+	require.False(t, ok)
+
+	// Second query is a cache hit, but the response block still re-learns.
+	server.handleDNSQuery(w, query)
+	_, ok = server.cnameAllowed.Get("a441.dscd.akamai.net")
+	assert.True(t, ok, "cache hit on origin should refresh the derived CNAME target")
+}
+
+// CNAME learning is independent of enforce/audit mode — it happens on the
+// response, not at the query gate.
+func TestHandleDNSQuery_CNAMELearnedInAuditMode(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "audit-*.json")
+	require.NoError(t, err)
+	tmpFile.Close()
+	auditLogger, err := events.NewAuditLogger(tmpFile.Name(), true) // audit mode = true
+	require.NoError(t, err)
+	defer auditLogger.Close()
+	server.auditLogger = auditLogger
+
+	const origin = "builds.dotnet.microsoft.com."
+	resp := makeCNAMEResponse(origin, []string{"a441.dscd.akamai.net"}, "23.56.109.139")
+	seedCachedResponse(server, origin, resp)
+
+	mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil).Once()
+
+	query := new(dns.Msg)
+	query.SetQuestion(origin, dns.TypeA)
+	query.Id = 6005
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	_, ok := server.cnameAllowed.Get("a441.dscd.akamai.net")
+	assert.True(t, ok, "CNAME learning must work in audit mode too")
 }
 
 // Counterpoint to the above: when a rule matches the stripped form (the K8s


### PR DESCRIPTION
Closes #62

## Problem

With `--dns-query-filtering` enabled (off by default; bundled into `--github-action` and `--gitlab-ci`), the DNS proxy REFUSES any query whose name matches no allow rule. This breaks **CNAME-chasing clients**: if `builds.dotnet.microsoft.com` (allowed by rule) CNAMEs to `a441.dscd.akamai.net`, a client that issues a *separate* query for the CNAME target gets REFUSED — forcing operators to wildcard on moving CDN targets (whack-a-mole).

Note the **IP-enforcement path already follows CNAMEs**: `extractIPsFromResponse` extracts every A/AAAA regardless of owner name and allow-lists them under the original rule. This PR closes the remaining gap — which CNAME-target *names* the query filter permits.

## Approach

Learn CNAME targets from **rule-allowed** responses into a TTL-bounded set, then permit later direct queries for them.

- New `cnameAllowed *lruCache[string, bool]` on the DNS server, reusing the existing generic LRU (`pkg/dns/lru.go`) — no new dependency. 10,000-entry cap, per-entry TTL from the response min.
- `handleDNSQuery`: after a rule-allowed response, record each CNAME target. Done *outside* the `len(ips)>0` guard so CNAME-only responses (no A/AAAA in the same message) still register. `MatchHostnameRule` is still called exactly once per response.
- `isQueryAllowed`: consult `cnameAllowed` **after** the rule deny check (so an explicit deny on the target still wins) and before the search-domain bypass. Nil-guarded for `Server` literals built without `NewServer`.

We learn only from rule-allowed responses, not from derived-allowed queries — a forwarding resolver returns the whole chain in one response, so transitive learning isn't needed and the surface stays bounded.

## Security

The only widening of the DNS-tunneling surface is which CNAME-target **names** may be queried, scoped to targets seen in rule-allowed responses, TTL-bounded, with deny rules still winning. This is within the trust already extended to an allowed host's upstream chain (IP enforcement already follows that chain). Rationale documented in `design.md`.

## Testing

- New unit tests for `isQueryAllowed` (derived allow, deny-overrides-derived, unknown refused, case-insensitive, expired) and `handleDNSQuery` (rule-allowed learns + target becomes queryable, CNAME-only learns, bypass-only does **not** learn, cache-hit refresh, audit-mode learns).
- `go build`, `go vet`, `staticcheck`, and `gofumpt` all clean; full `go test ./...` passes (`pkg/dns` is `//go:build linux`, run on Linux).

## Docs

- `README.md` — note on the `--dns-query-filtering` flag row.
- `design.md` — DNS query-filtering bullet expanded with behavior + security trade-off.
