### PR TITLE
#52 merge common rule entries

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -208,6 +208,7 @@ func (cm *Manager) applyLoadedConfig(cfg *FirewallConfig) error {
 	if err := validateRules(cfg.Rules); err != nil {
 		return err
 	}
+	cfg.Rules = mergeDuplicateRules(cfg.Rules)
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config = cfg
@@ -246,6 +247,47 @@ func validateRules(rules []Rule) error {
 		}
 	}
 	return nil
+}
+
+// ruleKey identifies rules that should have their ports unioned: rules that
+// agree on type, value, AND action are the same rule expressed more than once,
+// so their ports are additive. Opposite-action rules on the same value are a
+// genuine allow/deny conflict (not a union) and are left intact for the
+// matching-precedence logic — hence Action is part of the key.
+type ruleKey struct {
+	Type   RuleType
+	Value  string
+	Action Action
+}
+
+// mergeDuplicateRules collapses rules sharing (Type, Value, Action) into one
+// rule whose Ports are the union of the duplicates' ports, so a policy that
+// lists the same hostname (or CIDR) twice allows the sum of their ports rather
+// than just the last/first entry's (issue #52). Rule values are already
+// canonical when this runs (hostnames lowercased by normalizeRules). Output
+// preserves first-occurrence order and keeps the first occurrence's
+// AutoAddedType. The "empty Ports = all ports" sentinel is honoured by
+// unionPorts: any all-ports duplicate makes the whole group all-ports.
+//
+// Running this once at load time means every downstream consumer — hostname
+// matching (cm.resolvedRules), CIDR conflict detection (cm.config.Rules), and
+// firewall BPF writes — observes the same unioned port set.
+func mergeDuplicateRules(rules []Rule) []Rule {
+	merged := make([]Rule, 0, len(rules))
+	idxByKey := make(map[ruleKey]int, len(rules))
+	for _, rule := range rules {
+		key := ruleKey{Type: rule.Type, Value: rule.Value, Action: rule.Action}
+		if i, ok := idxByKey[key]; ok {
+			merged[i].Ports = unionPorts(merged[i].Ports, rule.Ports)
+			continue
+		}
+		idxByKey[key] = len(merged)
+		// Copy Ports so a later union (which reassigns merged[i].Ports) can
+		// never alias or mutate the caller's backing array.
+		rule.Ports = copyPorts(rule.Ports)
+		merged = append(merged, rule)
+	}
+	return merged
 }
 
 // kubernetesSearchDomains are always-active suffixes that the DNS proxy
@@ -886,7 +928,7 @@ func (cm *Manager) cleanupOldEntries() {
 //
 // Two rules can fire on a single lookup: one against the full hostname and
 // one against its search-domain-stripped form. When the actions match,
-// the verdict carries one side (deny ports unioned via mergeDenyPorts,
+// the verdict carries one side (deny ports unioned via unionPorts,
 // allow form picked via narrower-exact-wins). When actions differ — e.g.
 // `*.compute.internal: deny 80` + `bastion: allow 22` querying
 // `bastion.compute.internal` — BOTH sides are recorded so the firewall
@@ -941,7 +983,7 @@ func (v HostnameVerdict) Matched() bool { return v.HasDeny() || v.HasAllow() }
 // form are each evaluated against the rule set independently, then folded
 // into one verdict:
 //
-//   - Both deny: union the port lists (mergeDenyPorts); attribute the
+//   - Both deny: union the port lists (unionPorts); attribute the
 //     deny rule via pickDenyForm (narrower-exact-wins, broader-port-wins).
 //   - Both allow: pick the allow rule via pickAllowForm (narrower-exact-wins).
 //   - Mixed (one deny, one allow): both sides are recorded on the verdict
@@ -970,7 +1012,7 @@ func (cm *Manager) MatchHostnameRule(hostname string) HostnameVerdict {
 
 	// Same-action: collapse into one side of the verdict.
 	if actionFull == ActionDeny && actionStripped == ActionDeny {
-		mergedPorts := mergeDenyPorts(portsFull, portsStripped)
+		mergedPorts := unionPorts(portsFull, portsStripped)
 		denyRule := valueFull
 		if pickDenyForm(valueFull, hostname, portsFull, valueStripped, stripped, portsStripped) {
 			denyRule = valueStripped
@@ -1039,7 +1081,7 @@ func matchedExactly(ruleValue, hostname string) bool {
 //     (all-ports — empty Ports — absorbs any port-scoped rule).
 //  3. Otherwise full form wins (stable default).
 //
-// Port UNION across both rules is the caller's job (see mergeDenyPorts);
+// Port UNION across both rules is the caller's job (see unionPorts);
 // this helper only decides which form's value/name supplies attribution.
 func pickDenyForm(
 	valueFull, name string, portsFull []Port,
@@ -1149,12 +1191,12 @@ func copyPorts(ports []Port) []Port {
 	return out
 }
 
-// mergeDenyPorts returns the union of two port lists from overlapping deny
-// rules. An empty input means "all ports" — the broader of the two absorbs
-// the other, so the merge is also empty. Otherwise the result is the
+// unionPorts returns the union of two port lists from overlapping rules of the
+// same action. An empty input means "all ports" — the broader of the two
+// absorbs the other, so the merge is also empty. Otherwise the result is the
 // deduplicated concatenation of p1 then p2 (Port is a comparable struct, so
 // map-based dedup is exact across both Port number AND Protocol).
-func mergeDenyPorts(p1, p2 []Port) []Port {
+func unionPorts(p1, p2 []Port) []Port {
 	if len(p1) == 0 || len(p2) == 0 {
 		return nil
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -219,6 +219,199 @@ func TestResolveRules_Mixed(t *testing.T) {
 	}
 }
 
+// portSetEqual compares two port lists as unordered sets (mergeDuplicateRules
+// preserves a deterministic order, but the union semantics are what matter).
+func portSetEqual(a, b []Port) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[Port]int, len(a))
+	for _, p := range a {
+		counts[p]++
+	}
+	for _, p := range b {
+		counts[p]--
+	}
+	for _, c := range counts {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Issue #52: a policy that lists the same hostname/CIDR more than once must
+// allow the UNION of those entries' ports, not just one entry's. The merge
+// happens in applyLoadedConfig, so these tests drive it through
+// LoadConfigFromRules (the four loaders share that tail).
+
+func TestMergeDuplicateRules_HostnameAllowUnion(t *testing.T) {
+	tcp443 := Port{Port: 443, Protocol: ProtocolTCP}
+	tcp80 := Port{Port: 80, Protocol: ProtocolTCP}
+
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeHostname, Value: "github.com", Ports: []Port{tcp443}, Action: ActionAllow},
+		{Type: RuleTypeHostname, Value: "github.com", Ports: []Port{tcp80}, Action: ActionAllow},
+	}, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+
+	// The two entries collapse into one rule across both views.
+	if len(cm.config.Rules) != 1 {
+		t.Fatalf("config.Rules: expected 1 merged rule, got %d", len(cm.config.Rules))
+	}
+	if len(cm.resolvedRules) != 1 {
+		t.Fatalf("resolvedRules: expected 1 merged rule, got %d", len(cm.resolvedRules))
+	}
+
+	verdict := cm.MatchHostnameRule("github.com")
+	if !verdict.HasAllow() {
+		t.Fatalf("expected an allow verdict, got %+v", verdict)
+	}
+	if want := []Port{tcp443, tcp80}; !portSetEqual(verdict.AllowPorts, want) {
+		t.Errorf("AllowPorts = %v, want union %v", verdict.AllowPorts, want)
+	}
+}
+
+func TestMergeDuplicateRules_AllPortsSentinelAbsorbs(t *testing.T) {
+	tcp443 := Port{Port: 443, Protocol: ProtocolTCP}
+
+	// An all-ports entry (empty Ports) on either side makes the whole group
+	// all-ports, regardless of order.
+	for _, tc := range []struct {
+		name  string
+		rules []Rule
+	}{
+		{"all-ports first", []Rule{
+			{Type: RuleTypeHostname, Value: "example.com", Action: ActionAllow},
+			{Type: RuleTypeHostname, Value: "example.com", Ports: []Port{tcp443}, Action: ActionAllow},
+		}},
+		{"all-ports second", []Rule{
+			{Type: RuleTypeHostname, Value: "example.com", Ports: []Port{tcp443}, Action: ActionAllow},
+			{Type: RuleTypeHostname, Value: "example.com", Action: ActionAllow},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cm := NewConfigManager()
+			if err := cm.LoadConfigFromRules(tc.rules, ActionDeny); err != nil {
+				t.Fatalf("LoadConfigFromRules() error = %v", err)
+			}
+			verdict := cm.MatchHostnameRule("example.com")
+			if !verdict.HasAllow() {
+				t.Fatalf("expected an allow verdict, got %+v", verdict)
+			}
+			if len(verdict.AllowPorts) != 0 {
+				t.Errorf("AllowPorts = %v, want empty (all ports)", verdict.AllowPorts)
+			}
+		})
+	}
+}
+
+func TestMergeDuplicateRules_PatternUnion(t *testing.T) {
+	tcp443 := Port{Port: 443, Protocol: ProtocolTCP}
+	tcp80 := Port{Port: 80, Protocol: ProtocolTCP}
+
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeHostname, Value: "*.github.com", Ports: []Port{tcp443}, Action: ActionAllow},
+		{Type: RuleTypeHostname, Value: "*.github.com", Ports: []Port{tcp80}, Action: ActionAllow},
+	}, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	if len(cm.resolvedRules) != 1 {
+		t.Fatalf("resolvedRules: expected 1 merged pattern rule, got %d", len(cm.resolvedRules))
+	}
+	verdict := cm.MatchHostnameRule("api.github.com")
+	if want := []Port{tcp443, tcp80}; !portSetEqual(verdict.AllowPorts, want) {
+		t.Errorf("AllowPorts = %v, want union %v", verdict.AllowPorts, want)
+	}
+}
+
+func TestMergeDuplicateRules_DenyUnion(t *testing.T) {
+	tcp443 := Port{Port: 443, Protocol: ProtocolTCP}
+	tcp80 := Port{Port: 80, Protocol: ProtocolTCP}
+
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeHostname, Value: "blocked.example.com", Ports: []Port{tcp80}, Action: ActionDeny},
+		{Type: RuleTypeHostname, Value: "blocked.example.com", Ports: []Port{tcp443}, Action: ActionDeny},
+	}, ActionAllow); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	verdict := cm.MatchHostnameRule("blocked.example.com")
+	if !verdict.HasDeny() {
+		t.Fatalf("expected a deny verdict, got %+v", verdict)
+	}
+	if want := []Port{tcp80, tcp443}; !portSetEqual(verdict.DenyPorts, want) {
+		t.Errorf("DenyPorts = %v, want union %v", verdict.DenyPorts, want)
+	}
+}
+
+func TestMergeDuplicateRules_CIDRUnionVisibleToConflictCheck(t *testing.T) {
+	tcp80 := Port{Port: 80, Protocol: ProtocolTCP}
+	tcp443 := Port{Port: 443, Protocol: ProtocolTCP}
+
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeCIDR, Value: "1.2.3.4/32", Ports: []Port{tcp80}, Action: ActionDeny},
+		{Type: RuleTypeCIDR, Value: "1.2.3.4/32", Ports: []Port{tcp443}, Action: ActionDeny},
+	}, ActionAllow); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	if len(cm.config.Rules) != 1 {
+		t.Fatalf("config.Rules: expected 1 merged CIDR rule, got %d", len(cm.config.Rules))
+	}
+	if want := []Port{tcp80, tcp443}; !portSetEqual(cm.config.Rules[0].Ports, want) {
+		t.Errorf("merged CIDR ports = %v, want union %v", cm.config.Rules[0].Ports, want)
+	}
+
+	// CheckIPRuleConflict reads cm.config.Rules. Port 443 was only on the
+	// second duplicate; before the merge it was lost and this allow would
+	// have been reported as non-conflicting.
+	action, conflict, rule := cm.CheckIPRuleConflict(
+		net.ParseIP("1.2.3.4"), "host.example.com", ActionAllow, []Port{tcp443})
+	if !conflict || action != ActionDeny {
+		t.Errorf("CheckIPRuleConflict = (%v, %v, %q), want (deny, true, 1.2.3.4/32)", action, conflict, rule)
+	}
+}
+
+func TestMergeDuplicateRules_OppositeActionsNotMerged(t *testing.T) {
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeHostname, Value: "example.com", Ports: []Port{{Port: 443, Protocol: ProtocolTCP}}, Action: ActionAllow},
+		{Type: RuleTypeHostname, Value: "example.com", Ports: []Port{{Port: 80, Protocol: ProtocolTCP}}, Action: ActionDeny},
+	}, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	// Opposite actions are a conflict, not a union: both rules survive and the
+	// existing matching-precedence logic decides the verdict (unchanged).
+	if len(cm.config.Rules) != 2 {
+		t.Fatalf("config.Rules: expected 2 rules (no merge across actions), got %d", len(cm.config.Rules))
+	}
+}
+
+func TestMergeDuplicateRules_NoDuplicatesUnchanged(t *testing.T) {
+	rules := []Rule{
+		{Type: RuleTypeHostname, Value: "github.com", Ports: []Port{{Port: 443, Protocol: ProtocolTCP}}, Action: ActionAllow},
+		{Type: RuleTypeCIDR, Value: "8.8.8.8/32", Ports: []Port{{Port: 53, Protocol: ProtocolUDP}}, Action: ActionAllow},
+		{Type: RuleTypeHostname, Value: "npmjs.org", Ports: []Port{{Port: 443, Protocol: ProtocolTCP}}, Action: ActionAllow},
+	}
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules(rules, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	if len(cm.config.Rules) != len(rules) {
+		t.Fatalf("config.Rules: expected %d rules unchanged, got %d", len(rules), len(cm.config.Rules))
+	}
+	// First-occurrence order is preserved.
+	for i, want := range []string{"github.com", "8.8.8.8/32", "npmjs.org"} {
+		if cm.config.Rules[i].Value != want {
+			t.Errorf("config.Rules[%d].Value = %q, want %q", i, cm.config.Rules[i].Value, want)
+		}
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
 	// Create a temporary config file
 	tmpfile, err := os.CreateTemp("", "cargowall-test-*.json")
@@ -2251,9 +2444,9 @@ func TestUpdateDNSMapping(t *testing.T) {
 // Direct tests for unexported helpers (Phase 4)
 // =============================================================================
 
-// mergeDenyPorts: empty (all-ports) absorbs the other; otherwise dedup'd
+// unionPorts: empty (all-ports) absorbs the other; otherwise dedup'd
 // union. Port is a comparable struct, so {Port, Protocol} is the dedup key.
-func TestMergeDenyPorts(t *testing.T) {
+func TestUnionPorts(t *testing.T) {
 	tcp443 := Port{Port: 443, Protocol: ProtocolTCP}
 	tcp80 := Port{Port: 80, Protocol: ProtocolTCP}
 	udp443 := Port{Port: 443, Protocol: ProtocolUDP}
@@ -2273,9 +2466,9 @@ func TestMergeDenyPorts(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := mergeDenyPorts(tc.p1, tc.p2)
+			got := unionPorts(tc.p1, tc.p2)
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("mergeDenyPorts(%v, %v) = %v, want %v", tc.p1, tc.p2, got, tc.want)
+				t.Errorf("unionPorts(%v, %v) = %v, want %v", tc.p1, tc.p2, got, tc.want)
 			}
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -370,7 +370,8 @@ func TestMergeDuplicateRules_CIDRUnionVisibleToConflictCheck(t *testing.T) {
 	// second duplicate; before the merge it was lost and this allow would
 	// have been reported as non-conflicting.
 	action, conflict, rule := cm.CheckIPRuleConflict(
-		net.ParseIP("1.2.3.4"), "host.example.com", ActionAllow, []Port{tcp443})
+		net.ParseIP("1.2.3.4"), "host.example.com", ActionAllow, []Port{tcp443},
+	)
 	if !conflict || action != ActionDeny {
 		t.Errorf("CheckIPRuleConflict = (%v, %v, %q), want (deny, true, 1.2.3.4/32)", action, conflict, rule)
 	}


### PR DESCRIPTION
Closes #52

## Problem

When a policy lists the same hostname more than once, only one entry's allowed
ports took effect instead of the union — effectively "last/first one wins,"
silently dropping ports the operator configured.

Root cause: in `matchHostnameRuleLocked` each hostname rule is classified into a
single candidate slot, so a second rule for the same hostname overwrote (or was
discarded by) the first and its `Ports` were lost. The same class of bug
affected duplicate CIDR rules — `CheckIPRuleConflict` reads the raw
`cm.config.Rules` while firewall BPF writes read `cm.resolvedRules`, so split
ports across duplicate CIDRs weren't unioned either.

## Fix

A single, centralized merge step in the config layer:

- Added `mergeDuplicateRules`, called once in `applyLoadedConfig` (the shared
  tail of all four loaders) right after `normalizeRules`/`validateRules`. It
  collapses rules sharing `(Type, Value, Action)` into one rule whose `Ports`
  are the **union** of the duplicates'. Because both `cm.config.Rules` and
  `cm.resolvedRules` are built from this slice, every consumer — hostname
  matching, CIDR conflict detection, and firewall BPF writes — observes the same
  unioned port set, with no changes to the matching-precedence logic.
- Renamed `mergeDenyPorts` → `unionPorts` (action-neutral) and reused it for the
  union; the "empty Ports = all ports" sentinel is preserved (any all-ports
  duplicate makes the whole group all-ports).

### Scope decisions

- Union applies to **both hostnames and CIDRs**, keyed on the literal `Value`
  string.
- Union is scoped to a **matching action** — opposite `allow`/`deny` rules on
  the same value stay a conflict governed by the existing precedence logic
  (unchanged); you can't union an allow-set with a deny-set.

## Tests

Added 7 tests (driven through `LoadConfigFromRules`, which routes through the
merge): hostname allow-union, all-ports sentinel absorbing (both orders),
wildcard-pattern union, deny union, CIDR union visible to `CheckIPRuleConflict`,
opposite-action rules **not** merged, and a no-duplicates-unchanged guard.

`go test ./pkg/...`, `go vet ./...`, and `gofmt -l` all clean.

## Follow-ups (filed)

- #64 — Canonicalize CIDR rule values (IPv6 case, bare-IP vs `/32`,
  zero-compression) so equivalent forms dedup/match. This is why the merge keys
  on the literal string for now.
- #65 — Inconsistent hostname case in reporting (DNS-query wire case vs
  connection-event lowercase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
