### PR TITLE
#64 canonicalize cidr rules

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1279,15 +1279,14 @@ func (cm *Manager) CheckIPRuleConflict(ip net.IP, hostname string, hostnameActio
 			continue
 		}
 
-		// Parse CIDR
+		// Rule values are canonical explicit-prefix CIDRs — normalizeRules
+		// promotes bare IPs to /32 or /128 at load time — so ParseCIDR always
+		// succeeds. A parse failure means a malformed value that resolveRules
+		// already logged and skipped; skip it here too. A /32 or /128 host
+		// route matches only its exact IP via Contains, ranking most-specific
+		// at ones==32/128 (an IPv6 single IP correctly ranks as 128, not 32).
 		_, ipnet, err := net.ParseCIDR(cm.config.Rules[i].Value)
 		if err != nil {
-			// Try as single IP
-			if ruleIP := net.ParseIP(cm.config.Rules[i].Value); ruleIP != nil && ruleIP.Equal(ip) {
-				// Exact match is most specific (32 bits)
-				mostSpecificRule = &cm.config.Rules[i]
-				mostSpecificBits = 32
-			}
 			continue
 		}
 
@@ -1558,13 +1557,12 @@ func (cm *Manager) hasCIDRRuleAllPorts(ipStr string) bool {
 			continue
 		}
 
+		// Rule values are canonical explicit-prefix CIDRs (normalizeRules
+		// promotes bare IPs to /32 or /128 at load time), so ParseCIDR
+		// succeeds and host routes match via Contains; a parse failure is a
+		// malformed value resolveRules already skipped.
 		_, ipnet, err := net.ParseCIDR(rule.Value)
-		if err != nil {
-			ruleIP := net.ParseIP(rule.Value)
-			if ruleIP == nil || !ruleIP.Equal(ip) {
-				continue
-			}
-		} else if !ipnet.Contains(ip) {
+		if err != nil || !ipnet.Contains(ip) {
 			continue
 		}
 
@@ -1589,14 +1587,12 @@ func (cm *Manager) hasCIDRRule(ipStr string, port Port) bool {
 			continue
 		}
 
+		// Rule values are canonical explicit-prefix CIDRs (normalizeRules
+		// promotes bare IPs to /32 or /128 at load time), so ParseCIDR
+		// succeeds and host routes match via Contains; a parse failure is a
+		// malformed value resolveRules already skipped.
 		_, ipnet, err := net.ParseCIDR(rule.Value)
-		if err != nil {
-			// Try single IP
-			ruleIP := net.ParseIP(rule.Value)
-			if ruleIP == nil || !ruleIP.Equal(ip) {
-				continue
-			}
-		} else if !ipnet.Contains(ip) {
+		if err != nil || !ipnet.Contains(ip) {
 			continue
 		}
 
@@ -1935,7 +1931,12 @@ func (cm *Manager) resolveRulesLocked() error {
 		case RuleTypeCIDR:
 			_, ipnet, err := net.ParseCIDR(rule.Value)
 			if err != nil {
-				// Try parsing as single IP (treat as /32)
+				// Load-time normalizeRules canonicalises bare IPs to explicit
+				// /32 or /128 prefixes, so the ParseCIDR above succeeds for
+				// every config-sourced rule. This single-IP fallback only
+				// fires when resolveRules is driven directly with un-normalized
+				// rules (the public resolveRules() test wrapper) — production
+				// loaders always normalize first.
 				ip := net.ParseIP(rule.Value)
 				if ip == nil {
 					slog.Error("Invalid CIDR/IP", "value", rule.Value, "error", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,6 +195,34 @@ func isIPv6CIDR(value string) bool {
 	return err == nil && ip.To4() == nil
 }
 
+// canonicalCIDR returns the canonical string form of a CIDR or bare-IP rule
+// value, so textually-different-but-equivalent values collapse to one entry:
+//
+//   - "2001:DB8::/32"     → "2001:db8::/32"   (IPv6 case-folded)
+//   - "2001:db8:0:0::/64" → "2001:db8::/64"   (zero-compression canonicalised)
+//   - "8.8.8.8"           → "8.8.8.8/32"      (bare IPv4 → explicit /32)
+//   - "2001:db8::1"       → "2001:db8::1/128" (bare IPv6 → explicit /128)
+//   - "10.0.0.5/8"        → "10.0.0.0/8"      (host bits masked to network)
+//
+// net.ParseCIDR already lower-cases IPv6, collapses zero runs, and masks host
+// bits off the network address — exactly the canonical form ipnet.String()
+// re-emits. Bare IPs (no prefix) are promoted to a single-host /32 or /128 so
+// "8.8.8.8" and "8.8.8.8/32" dedup. Values that parse as neither are returned
+// unchanged; resolveRules logs them as invalid and skips them.
+func canonicalCIDR(value string) string {
+	if _, ipnet, err := net.ParseCIDR(value); err == nil {
+		return ipnet.String()
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		return value
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		return (&net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)}).String()
+	}
+	return (&net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}).String()
+}
+
 // applyLoadedConfig is the shared tail of every Load* loader: normalize
 // and validate the rule set, then atomically swap cm.config under the
 // write lock and resolve rules. If normalization or validation fails the
@@ -216,18 +244,28 @@ func (cm *Manager) applyLoadedConfig(cfg *FirewallConfig) error {
 }
 
 // normalizeRules canonicalises rule values in place so cm.config.Rules and
-// cm.resolvedRules agree byte-for-byte. Today that's hostname-rule values:
-// DNS is case-insensitive but JSON / proto / env can carry mixed case
-// (e.g. "GitHub.com"), and MatchHostnameRule lowercases the lookup key —
-// so rule values must also be lowercased once at load time.
+// cm.resolvedRules agree byte-for-byte, and so equivalent-but-differently-
+// spelled values dedup in mergeDuplicateRules (which keys on the literal
+// Value string):
 //
-// All four loaders call this before resolveRules, so any code reading
-// cm.config.Rules directly (audit / introspection) sees the same canonical
-// form that MatchHostnameRule matches against.
+//   - Hostname rules are lower-cased. DNS is case-insensitive but JSON /
+//     proto / env can carry mixed case (e.g. "GitHub.com"), and
+//     MatchHostnameRule lowercases the lookup key.
+//   - CIDR rules are canonicalised via canonicalCIDR: IPv6 case-folded and
+//     zero-compressed, bare IPs promoted to /32 or /128, host bits masked.
+//     So "2001:DB8::/32" and "2001:db8::/32", or "8.8.8.8" and "8.8.8.8/32",
+//     become one entry rather than two (issue #64).
+//
+// All four loaders call this before validateRules / mergeDuplicateRules /
+// resolveRules, so any code reading cm.config.Rules directly (audit /
+// introspection) sees the same canonical form that matching runs against.
 func normalizeRules(rules []Rule) {
 	for i := range rules {
-		if rules[i].Type == RuleTypeHostname {
+		switch rules[i].Type {
+		case RuleTypeHostname:
 			rules[i].Value = strings.ToLower(rules[i].Value)
+		case RuleTypeCIDR:
+			rules[i].Value = canonicalCIDR(rules[i].Value)
 		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1942,7 +1942,7 @@ func (cm *Manager) resolveRulesLocked() error {
 					slog.Error("Invalid CIDR/IP", "value", rule.Value, "error", err)
 					continue
 				}
-				// Convert single IP to /32 CIDR
+				// Convert single IP to a host route: /32 for IPv4, /128 for IPv6.
 				if ip4 := ip.To4(); ip4 != nil {
 					resolved.IPNet = &net.IPNet{
 						IP:   ip4,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1279,12 +1279,12 @@ func (cm *Manager) CheckIPRuleConflict(ip net.IP, hostname string, hostnameActio
 			continue
 		}
 
-		// Rule values are canonical explicit-prefix CIDRs — normalizeRules
-		// promotes bare IPs to /32 or /128 at load time — so ParseCIDR always
-		// succeeds. A parse failure means a malformed value that resolveRules
-		// already logged and skipped; skip it here too. A /32 or /128 host
-		// route matches only its exact IP via Contains, ranking most-specific
-		// at ones==32/128 (an IPv6 single IP correctly ranks as 128, not 32).
+		// normalizeRules promotes bare IPs to explicit /32 or /128 prefixes at
+		// load time, so every valid CIDR rule parses here; the only ParseCIDR
+		// failure left is a malformed value that resolveRules already logged
+		// and skipped, so skip it here too. A /32 or /128 host route matches
+		// only its exact IP via Contains, ranking most-specific at ones==32/128
+		// (an IPv6 single IP correctly ranks as 128, not 32).
 		_, ipnet, err := net.ParseCIDR(cm.config.Rules[i].Value)
 		if err != nil {
 			continue
@@ -1557,10 +1557,10 @@ func (cm *Manager) hasCIDRRuleAllPorts(ipStr string) bool {
 			continue
 		}
 
-		// Rule values are canonical explicit-prefix CIDRs (normalizeRules
-		// promotes bare IPs to /32 or /128 at load time), so ParseCIDR
-		// succeeds and host routes match via Contains; a parse failure is a
-		// malformed value resolveRules already skipped.
+		// normalizeRules promotes bare IPs to explicit /32 or /128 prefixes at
+		// load time, so every valid CIDR rule parses and host routes match via
+		// Contains; the only remaining ParseCIDR failure is a malformed value
+		// resolveRules already skipped, so skip it here too.
 		_, ipnet, err := net.ParseCIDR(rule.Value)
 		if err != nil || !ipnet.Contains(ip) {
 			continue
@@ -1587,10 +1587,10 @@ func (cm *Manager) hasCIDRRule(ipStr string, port Port) bool {
 			continue
 		}
 
-		// Rule values are canonical explicit-prefix CIDRs (normalizeRules
-		// promotes bare IPs to /32 or /128 at load time), so ParseCIDR
-		// succeeds and host routes match via Contains; a parse failure is a
-		// malformed value resolveRules already skipped.
+		// normalizeRules promotes bare IPs to explicit /32 or /128 prefixes at
+		// load time, so every valid CIDR rule parses and host routes match via
+		// Contains; the only remaining ParseCIDR failure is a malformed value
+		// resolveRules already skipped, so skip it here too.
 		_, ipnet, err := net.ParseCIDR(rule.Value)
 		if err != nil || !ipnet.Contains(ip) {
 			continue

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2095,12 +2095,10 @@ func TestPickAllowForm(t *testing.T) {
 	}
 }
 
-// normalizeRules canonicalises hostname rule values at load time so
-// cm.config.Rules and cm.resolvedRules share the same byte sequence.
-// CIDR values are left untouched (case is meaningless for CIDRs and IPv6
-// "::1" would be mangled by ToLower of nothing, but defensiveness costs
-// nothing).
-func TestNormalizeRules_LowercasesHostnameOnly(t *testing.T) {
+// normalizeRules canonicalises rule values at load time so cm.config.Rules
+// and cm.resolvedRules share the same byte sequence: hostnames are
+// lower-cased and CIDRs are canonicalised (issue #64).
+func TestNormalizeRules_CanonicalisesHostnameAndCIDR(t *testing.T) {
 	rules := []Rule{
 		{Type: RuleTypeHostname, Value: "GitHub.COM", Action: ActionAllow},
 		{Type: RuleTypeHostname, Value: "*.Example.NET", Action: ActionAllow},
@@ -2114,7 +2112,73 @@ func TestNormalizeRules_LowercasesHostnameOnly(t *testing.T) {
 		t.Errorf("hostname[1] = %q, want %q", rules[1].Value, "*.example.net")
 	}
 	if rules[2].Value != "10.0.0.0/8" {
-		t.Errorf("CIDR rule should not be normalized: got %q", rules[2].Value)
+		t.Errorf("already-canonical CIDR changed: got %q", rules[2].Value)
+	}
+}
+
+// canonicalCIDR collapses textually-different-but-equivalent CIDR/IP forms to
+// one canonical string (issue #64), and leaves unparseable values untouched so
+// resolveRules can log them.
+func TestCanonicalCIDR(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"already-canonical IPv4 CIDR", "10.0.0.0/8", "10.0.0.0/8"},
+		{"bare IPv4 → /32", "8.8.8.8", "8.8.8.8/32"},
+		{"explicit /32 unchanged", "8.8.8.8/32", "8.8.8.8/32"},
+		{"IPv4 host bits masked", "10.0.0.5/8", "10.0.0.0/8"},
+		{"IPv6 case-folded", "2001:DB8::/32", "2001:db8::/32"},
+		{"IPv6 zero-compression canonicalised", "2001:db8:0:0::/64", "2001:db8::/64"},
+		{"bare IPv6 → /128", "2001:db8::1", "2001:db8::1/128"},
+		{"bare IPv6 case-folded → /128", "2001:DB8::1", "2001:db8::1/128"},
+		{"unparseable left untouched", "not-a-cidr", "not-a-cidr"},
+		{"empty left untouched", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalCIDR(tc.in); got != tc.want {
+				t.Errorf("canonicalCIDR(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Equivalent-but-differently-spelled CIDR forms must collapse to one rule and
+// union their ports through the load-time merge (issue #64), the CIDR analogue
+// of TestMergeDuplicateRules_HostnameAllowUnion.
+func TestMergeDuplicateRules_EquivalentCIDRFormsUnion(t *testing.T) {
+	tcp443 := Port{Port: 443, Protocol: ProtocolTCP}
+	tcp80 := Port{Port: 80, Protocol: ProtocolTCP}
+
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules([]Rule{
+		// Same /128 host expressed as upper-case prefix, bare IP, and
+		// lower-case prefix — three spellings of one rule.
+		{Type: RuleTypeCIDR, Value: "2001:DB8::1/128", Ports: []Port{tcp443}, Action: ActionAllow},
+		{Type: RuleTypeCIDR, Value: "2001:db8::1", Ports: []Port{tcp80}, Action: ActionAllow},
+		{Type: RuleTypeCIDR, Value: "2001:db8:0:0::1/128", Action: ActionAllow},
+	}, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+
+	cidrRules := make([]Rule, 0, len(cm.config.Rules))
+	for _, r := range cm.config.Rules {
+		if r.Type == RuleTypeCIDR {
+			cidrRules = append(cidrRules, r)
+		}
+	}
+	if len(cidrRules) != 1 {
+		t.Fatalf("got %d CIDR rules, want 1 (equivalent forms should merge): %+v", len(cidrRules), cidrRules)
+	}
+	if cidrRules[0].Value != "2001:db8::1/128" {
+		t.Errorf("merged CIDR value = %q, want %q", cidrRules[0].Value, "2001:db8::1/128")
+	}
+	// The third entry carries no ports — the all-ports sentinel absorbs the
+	// rest, so the union is all-ports (empty).
+	if len(cidrRules[0].Ports) != 0 {
+		t.Errorf("merged ports = %v, want all-ports (empty)", cidrRules[0].Ports)
 	}
 }
 
@@ -2220,7 +2284,9 @@ func TestCheckIPRuleConflict(t *testing.T) {
 			wantConflict:   false,
 		},
 		{
-			name: "single-IP rule treated as /32",
+			// A bare IP is canonicalised to an explicit /32 at load time
+			// (issue #64), so the reported conflicting rule is "10.0.0.5/32".
+			name: "single-IP rule canonicalised to /32",
 			rules: []Rule{
 				{Type: RuleTypeCIDR, Value: "10.0.0.5", Action: ActionDeny},
 			},
@@ -2228,7 +2294,7 @@ func TestCheckIPRuleConflict(t *testing.T) {
 			hostnameAction: ActionAllow,
 			wantAction:     ActionDeny,
 			wantConflict:   true,
-			wantRuleValue:  "10.0.0.5",
+			wantRuleValue:  "10.0.0.5/32",
 		},
 	}
 


### PR DESCRIPTION
Closes #64.

## Problem

`normalizeRules` lowercased hostname rule values but left **CIDR** values untouched, so textually-different-but-equivalent CIDRs were treated as distinct entries — they wouldn't dedup/merge ports in the #52 rule-merge (which keys on the literal `Value` string) and produced confusing duplicate audit output. Examples:

- IPv6 case: `2001:DB8::/32` vs `2001:db8::/32`
- bare IP vs explicit prefix: `8.8.8.8` vs `8.8.8.8/32`
- non-canonical zero-compression: `2001:db8:0:0::/64` vs `2001:db8::/64`

## Change

Canonicalize CIDR `Value` at load time in `normalizeRules`, alongside the existing hostname lowercasing. A new `canonicalCIDR` helper parses via `net.ParseCIDR` / `net.ParseIP`, promotes bare IPs to `/32` / `/128`, and re-emits the canonical `IPNet.String()`:

| input | output | reason |
|---|---|---|
| `2001:DB8::/32` | `2001:db8::/32` | IPv6 case-folded |
| `2001:db8:0:0::/64` | `2001:db8::/64` | zero-compression canonicalised |
| `8.8.8.8` | `8.8.8.8/32` | bare IPv4 → explicit /32 |
| `2001:db8::1` | `2001:db8::1/128` | bare IPv6 → explicit /128 |
| `10.0.0.5/8` | `10.0.0.0/8` | host bits masked to network |

Values that parse as neither are returned unchanged, so `resolveRules` still logs and skips them. This keeps the existing "`config.Rules` and `resolvedRules` agree byte-for-byte" invariant that hostname lowercasing already relies on, and runs once at load time so every downstream consumer (hostname matching, CIDR conflict detection, BPF writes, audit) sees one canonical form.

### Knock-on cleanup

Because every config-sourced CIDR value is now an explicit-prefix CIDR, the bare-IP `net.ParseIP` fallbacks in `CheckIPRuleConflict`, `hasCIDRRule`, and `hasCIDRRuleAllPorts` (which only ever read post-load canonical rules) are dead and were removed — a `/32` / `/128` host route matches its exact IP via `IPNet.Contains` identically. As a bonus this fixes a latent specificity bug where an IPv6 single-IP rule was hard-coded to rank as 32 bits; it now correctly ranks as 128. `resolveRulesLocked` keeps its single-IP fallback (now annotated) because the public `resolveRules()` test wrapper drives it with un-normalized rules.

## Behavior notes

- Audit strings for CIDR rules now show the canonical form (e.g. a conflicting rule reported as `10.0.0.5/32` rather than `10.0.0.5`, or `10.0.0.0/8` rather than `10.0.0.5/8`). This is the intended dedup/clarity improvement from #64.
- The default-route exact-string special-cases in `firewall.go` (`== "0.0.0.0/0"` / `== "::/0"`) are unaffected — those strings are already canonical — and now also catch non-canonical spellings of the wildcard route.
- **Stricter load validation (intended):** an ICMP-port rule on a *bare* IPv6 address (e.g. `2001:db8::1`) now fails load, because canonicalization to `/128` makes `isIPv6CIDR` true and `validateRules` rejects ICMP-on-IPv6 (proto 1 is IPv4-only). The explicit-`/128` form already failed; this makes the bare and explicit forms consistent.

## Testing

- New `TestCanonicalCIDR` (table-driven: all issue cases + unparseable/empty passthrough).
- New `TestMergeDuplicateRules_EquivalentCIDRFormsUnion` — three spellings of one IPv6 host collapse to a single rule with unioned ports.
- Updated `TestNormalizeRules_*` and the `CheckIPRuleConflict` single-IP case to expect the canonical form.
- `go build`, `go vet`, `gofumpt`, and `go test ./pkg/config/ ./pkg/dns/...` all green (run under `GOOS=linux` / Linux container; the package is `//go:build linux`). The only failing suite is the privileged eBPF tests (`bpf`, `pkg/tc`), which require root and are unrelated.
