### PR TITLE
#65 normalize hostname case to lowercase in reporting

### DIFF
--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -320,7 +320,10 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	// DNS tunneling). isQueryAllowed handles both the full and the
 	// search-domain-stripped form internally with the right precedence.
 	if s.filterQueries && len(r.Question) > 0 {
-		domain := strings.TrimSuffix(r.Question[0].Name, ".")
+		// Lowercased for reporting consistency (#65): isQueryAllowed and
+		// MatchHostnameRule fold case internally, so this only affects the
+		// case shown in the block logs and the LogDNSBlocked audit record.
+		domain := strings.ToLower(strings.TrimSuffix(r.Question[0].Name, "."))
 		if !s.isQueryAllowed(domain, r.Question[0].Qtype) {
 			// Check if we're in audit mode - log but don't block
 			isAuditMode := s.auditLogger != nil && s.auditLogger.IsAuditMode()
@@ -412,15 +415,15 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 	// Process response before returning replying
 	if len(r.Question) > 0 && resp.Rcode == dns.RcodeSuccess {
-		fullHostname := strings.TrimSuffix(r.Question[0].Name, ".")
+		// Lowercase the queried name once and use it for matching, per-host
+		// bookkeeping, AND log/audit attribution. Reporting the canonical
+		// lowercase form (rather than the raw wire case) keeps DNS-path output
+		// consistent with the connection-event path, which logs the lowercase
+		// hostname from the IP->hostname mapping (#65).
+		canonicalHostname := strings.ToLower(strings.TrimSuffix(r.Question[0].Name, "."))
 
 		// Extract IPs and TTLs from response
 		ips, ttl := s.extractIPsFromResponse(resp)
-
-		// Lowercase once for all canonical-form operations below; keep
-		// fullHostname for log attribution so wire-case is preserved in
-		// audit/debug output.
-		canonicalHostname := strings.ToLower(fullHostname)
 
 		// One MatchHostnameRule call per resolution — it internally evaluates
 		// both the full and search-domain-stripped forms and folds the result
@@ -494,7 +497,7 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 		if len(ips) > 0 {
 			s.logger.Debug("DNS resolution intercepted",
-				"hostname", fullHostname,
+				"hostname", canonicalHostname,
 				"ip_count", len(ips),
 				"ttl", ttl)
 
@@ -511,7 +514,7 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			// target of an allowed host whose IPs must be enforced.
 			if bypassOnly && !verdict.Matched() && !derived {
 				s.logger.Debug("Skipping per-host tracking for bypass-only hostname",
-					"hostname", fullHostname,
+					"hostname", canonicalHostname,
 					"ip_count", len(ips))
 			} else {
 				for _, ip := range ips {
@@ -535,7 +538,7 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				switch {
 				case verdict.Matched() && s.firewall != nil:
 					s.logger.Debug("Hostname tracked for BPF update",
-						"hostname", fullHostname,
+						"hostname", canonicalHostname,
 						"deny_rule", verdict.DenyRule,
 						"deny_ports", verdict.DenyPorts,
 						"allow_rule", verdict.AllowRule,
@@ -543,10 +546,10 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 					for _, ip := range ips {
 						if verdict.HasDeny() {
-							s.applyVerdictSide(ip, fullHostname, config.ActionDeny, verdict.DenyPorts, false)
+							s.applyVerdictSide(ip, canonicalHostname, config.ActionDeny, verdict.DenyPorts, false)
 						}
 						if verdict.HasAllow() {
-							s.applyVerdictSide(ip, fullHostname, config.ActionAllow, verdict.AllowPorts, false)
+							s.applyVerdictSide(ip, canonicalHostname, config.ActionAllow, verdict.AllowPorts, false)
 						}
 					}
 				case derived && s.firewall != nil:
@@ -557,18 +560,18 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 					// un-REFUSED. applyVerdictSide keeps the CIDR-conflict check
 					// and the default-action short-circuit.
 					s.logger.Debug("Hostname tracked for BPF update (derived CNAME allow)",
-						"hostname", fullHostname,
+						"hostname", canonicalHostname,
 						"allow_ports", derivedPorts)
 
 					for _, ip := range ips {
-						s.applyVerdictSide(ip, fullHostname, config.ActionAllow, derivedPorts, false)
+						s.applyVerdictSide(ip, canonicalHostname, config.ActionAllow, derivedPorts, false)
 					}
 				case !verdict.Matched():
 					// No rules yet, but track that we've seen this hostname
 					// so ApplyRulesToTrackedHostnames can backfill if a rule
 					// is added later.
 					s.logger.Debug("DNS resolution tracked (no rules yet)",
-						"hostname", fullHostname,
+						"hostname", canonicalHostname,
 						"ip_count", len(ips))
 				}
 			}

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -18,6 +18,7 @@ package dns
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1474,6 +1475,67 @@ func TestHandleDNSQuery_FilteringEnforceBlocks(t *testing.T) {
 	w.AssertExpectations(t)
 	require.NotNil(t, w.msg)
 	assert.Equal(t, dns.RcodeRefused, w.msg.Rcode, "blocked domain should get REFUSED")
+}
+
+// #65: a DNS-path audit record must report the canonical lowercase hostname,
+// not the raw wire case, so it agrees with the connection-event path (which
+// logs the lowercase IP->hostname mapping). A mixed-case blocked query is the
+// observable surface for this on the query-filtering path.
+func TestHandleDNSQuery_BlockedQueryReportedLowercase(t *testing.T) {
+	cfg := config.NewConfigManager()
+	err := cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "allowed.example.com", Action: config.ActionAllow},
+	}, config.ActionDeny)
+	require.NoError(t, err)
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "audit-*.json")
+	require.NoError(t, err)
+	tmpFile.Close()
+	auditLogger, err := events.NewAuditLogger(tmpFile.Name(), false) // enforce mode
+	require.NoError(t, err)
+	defer auditLogger.Close()
+	server.auditLogger = auditLogger
+
+	// Mixed-case query for a domain with no allow rule -> blocked (REFUSED).
+	query := new(dns.Msg)
+	query.SetQuestion("Evil.Tunnel.Example.COM.", dns.TypeA)
+	query.Id = 5252
+
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+
+	server.handleDNSQuery(w, query)
+
+	w.AssertExpectations(t)
+	require.NotNil(t, w.msg)
+	assert.Equal(t, dns.RcodeRefused, w.msg.Rcode)
+
+	evs := readDNSAuditEvents(t, tmpFile.Name())
+	require.Len(t, evs, 1)
+	assert.Equal(t, events.EventDNSBlocked, evs[0].EventType)
+	assert.Equal(t, "evil.tunnel.example.com", evs[0].DstHostname,
+		"blocked query hostname must be reported lowercase (#65)")
+}
+
+// readDNSAuditEvents reads JSONL audit records written by events.AuditLogger.
+func readDNSAuditEvents(t *testing.T, path string) []events.AuditEvent {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var evs []events.AuditEvent
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev events.AuditEvent
+		require.NoError(t, json.Unmarshal([]byte(line), &ev))
+		evs = append(evs, ev)
+	}
+	return evs
 }
 
 func TestHandleDNSQuery_FilteringAuditModePassesThrough(t *testing.T) {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -284,7 +284,11 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 			names, err := reverseDNSResolver.LookupAddr(ctx, dstIP)
 			cancel()
 			if err == nil && len(names) > 0 {
-				ptrName := strings.TrimSuffix(names[0], ".")
+				// Lowercased so an unmatched PTR name is reported in the same
+				// canonical case as forward mappings and tracked-rule matches,
+				// keeping connection-event output consistent (#65). PTR replies
+				// can carry mixed/0x20-randomized case off the wire.
+				ptrName := strings.ToLower(strings.TrimSuffix(names[0], "."))
 				// Try to match PTR result to a tracked hostname
 				if tracked := configMgr.FindTrackedHostname(ptrName); tracked != "" {
 					hostname = tracked


### PR DESCRIPTION
Closes #65.

## Problem

Hostname **matching** is uniformly case-insensitive, but the hostname **case shown in logs / audit output** differed by subsystem:

- **DNS proxy path** (`pkg/dns/server.go`) deliberately kept the raw wire-case `fullHostname` for attribution.
- **Connection-event path** (`pkg/events/events.go`) mostly reported the canonical lowercase form from the IP→hostname mapping.

Net effect: the same host could appear as `GitHub.com` on a DNS-query audit line and `github.com` on a connection-event line. Not an enforcement bug — purely a reporting inconsistency.

## Fix

Normalize on **lowercase** everywhere (matching the stored mappings):

- **DNS resolution intercept** — drop the separate wire-case `fullHostname`; use the lowercased `canonicalHostname` for all log / audit / `applyVerdictSide` attribution.
- **DNS query filtering** — lowercase `domain` so the block logs and the `LogDNSBlocked` audit record are lowercase. `isQueryAllowed` / `MatchHostnameRule` fold case internally, so matching behavior is unchanged.
- **Connection-event PTR path** — lowercase an unmatched PTR name (PTR replies can carry mixed / 0x20-randomized case off the wire). `FindTrackedHostname` and `UpdateDNSMapping` already lowercase internally, so this only closes the "mostly" gap.

## Testing

- New `TestHandleDNSQuery_BlockedQueryReportedLowercase`: a mixed-case blocked query (`Evil.Tunnel.Example.COM.`) is recorded as `evil.tunnel.example.com` in the audit log.
- `go test ./pkg/dns/... ./pkg/events/... ./pkg/config/...` pass on linux (run in a `golang:1.25` container). The eBPF tests (`bpf`, `pkg/tc`) require privileged kernel access and are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)