### PR TITLE
#72 CNAME attribution reporting

### DIFF
--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -668,8 +668,8 @@ func auditEventToProto(e events.AuditEvent) *cargowallv1.CargoWallActionEvent {
 			event.AutoAllowedType = &autoType
 		}
 	}
-	if len(e.CNAMETarget) > 0 {
-		event.CnameTarget = e.CNAMETarget
+	if len(e.CNAMEChain) > 0 {
+		event.CnameChain = e.CNAMEChain
 	}
 	return event
 }

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -668,6 +668,9 @@ func auditEventToProto(e events.AuditEvent) *cargowallv1.CargoWallActionEvent {
 			event.AutoAllowedType = &autoType
 		}
 	}
+	if len(e.CNAMETarget) > 0 {
+		event.CnameTarget = e.CNAMETarget
+	}
 	return event
 }
 

--- a/pb/cargowall/v1/cargo_wall_action.pb.go
+++ b/pb/cargowall/v1/cargo_wall_action.pb.go
@@ -256,8 +256,12 @@ type CargoWallActionEvent struct {
 	Process         *string                        `protobuf:"bytes,8,opt,name=process,proto3,oneof" json:"process,omitempty"`
 	Category        data.CargoWallEventCategory    `protobuf:"varint,9,opt,name=category,proto3,enum=grpc.cargowall.v1.CargoWallEventCategory" json:"category,omitempty"`
 	AutoAllowedType *data.CargoWallAutoAllowedType `protobuf:"varint,10,opt,name=auto_allowed_type,json=autoAllowedType,proto3,enum=grpc.cargowall.v1.CargoWallAutoAllowedType,oneof" json:"auto_allowed_type,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Full CNAME chain (origin..target) when the hostname was reached via a CNAME
+	// of an allowed host; empty otherwise. The first element is the origin the
+	// user allowed, the last is the edge/target actually connected to.
+	CnameTarget   []string `protobuf:"bytes,11,rep,name=cname_target,json=cnameTarget,proto3" json:"cname_target,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CargoWallActionEvent) Reset() {
@@ -358,6 +362,13 @@ func (x *CargoWallActionEvent) GetAutoAllowedType() data.CargoWallAutoAllowedTyp
 		return *x.AutoAllowedType
 	}
 	return data.CargoWallAutoAllowedType(0)
+}
+
+func (x *CargoWallActionEvent) GetCnameTarget() []string {
+	if x != nil {
+		return x.CnameTarget
+	}
+	return nil
 }
 
 type CreateCargoWallActionJobRequest struct {
@@ -641,7 +652,7 @@ const file_cargo_wall_action_proto_rawDesc = "" +
 	"\fcompleted_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\vcompletedAt\x88\x01\x01\x12?\n" +
 	"\x06events\x18d \x03(\v2'.grpc.cargowall.v1.CargoWallActionEventR\x06eventsB\r\n" +
 	"\v_started_atB\x0f\n" +
-	"\r_completed_at\"\xc9\x04\n" +
+	"\r_completed_at\"\xec\x04\n" +
 	"\x14CargoWallActionEvent\x128\n" +
 	"\ttimestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12>\n" +
 	"\x06action\x18\x02 \x01(\x0e2&.grpc.cargowall.v1.CargoWallActionTypeR\x06action\x12\x1f\n" +
@@ -653,7 +664,8 @@ const file_cargo_wall_action_proto_rawDesc = "" +
 	"\aprocess\x18\b \x01(\tH\x05R\aprocess\x88\x01\x01\x12E\n" +
 	"\bcategory\x18\t \x01(\x0e2).grpc.cargowall.v1.CargoWallEventCategoryR\bcategory\x12\\\n" +
 	"\x11auto_allowed_type\x18\n" +
-	" \x01(\x0e2+.grpc.cargowall.v1.CargoWallAutoAllowedTypeH\x06R\x0fautoAllowedType\x88\x01\x01B\v\n" +
+	" \x01(\x0e2+.grpc.cargowall.v1.CargoWallAutoAllowedTypeH\x06R\x0fautoAllowedType\x88\x01\x01\x12!\n" +
+	"\fcname_target\x18\v \x03(\tR\vcnameTargetB\v\n" +
 	"\t_hostnameB\x05\n" +
 	"\x03_ipB\a\n" +
 	"\x05_portB\v\n" +

--- a/pb/cargowall/v1/cargo_wall_action.pb.go
+++ b/pb/cargowall/v1/cargo_wall_action.pb.go
@@ -259,7 +259,7 @@ type CargoWallActionEvent struct {
 	// Full CNAME chain (origin..target) when the hostname was reached via a CNAME
 	// of an allowed host; empty otherwise. The first element is the origin the
 	// user allowed, the last is the edge/target actually connected to.
-	CnameTarget   []string `protobuf:"bytes,11,rep,name=cname_target,json=cnameTarget,proto3" json:"cname_target,omitempty"`
+	CnameChain    []string `protobuf:"bytes,11,rep,name=cname_chain,json=cnameChain,proto3" json:"cname_chain,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -364,9 +364,9 @@ func (x *CargoWallActionEvent) GetAutoAllowedType() data.CargoWallAutoAllowedTyp
 	return data.CargoWallAutoAllowedType(0)
 }
 
-func (x *CargoWallActionEvent) GetCnameTarget() []string {
+func (x *CargoWallActionEvent) GetCnameChain() []string {
 	if x != nil {
-		return x.CnameTarget
+		return x.CnameChain
 	}
 	return nil
 }
@@ -652,7 +652,7 @@ const file_cargo_wall_action_proto_rawDesc = "" +
 	"\fcompleted_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\vcompletedAt\x88\x01\x01\x12?\n" +
 	"\x06events\x18d \x03(\v2'.grpc.cargowall.v1.CargoWallActionEventR\x06eventsB\r\n" +
 	"\v_started_atB\x0f\n" +
-	"\r_completed_at\"\xec\x04\n" +
+	"\r_completed_at\"\xea\x04\n" +
 	"\x14CargoWallActionEvent\x128\n" +
 	"\ttimestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12>\n" +
 	"\x06action\x18\x02 \x01(\x0e2&.grpc.cargowall.v1.CargoWallActionTypeR\x06action\x12\x1f\n" +
@@ -664,8 +664,9 @@ const file_cargo_wall_action_proto_rawDesc = "" +
 	"\aprocess\x18\b \x01(\tH\x05R\aprocess\x88\x01\x01\x12E\n" +
 	"\bcategory\x18\t \x01(\x0e2).grpc.cargowall.v1.CargoWallEventCategoryR\bcategory\x12\\\n" +
 	"\x11auto_allowed_type\x18\n" +
-	" \x01(\x0e2+.grpc.cargowall.v1.CargoWallAutoAllowedTypeH\x06R\x0fautoAllowedType\x88\x01\x01\x12!\n" +
-	"\fcname_target\x18\v \x03(\tR\vcnameTargetB\v\n" +
+	" \x01(\x0e2+.grpc.cargowall.v1.CargoWallAutoAllowedTypeH\x06R\x0fautoAllowedType\x88\x01\x01\x12\x1f\n" +
+	"\vcname_chain\x18\v \x03(\tR\n" +
+	"cnameChainB\v\n" +
 	"\t_hostnameB\x05\n" +
 	"\x03_ipB\a\n" +
 	"\x05_portB\v\n" +

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1028,11 +1028,14 @@ func (cm *Manager) LookupCNAMEChain(ip string) []string {
 	now := time.Now()
 	best := -1       // most-recent non-expired
 	mostRecent := -1 // most-recent overall (fallback when all expired)
+	// Use !Before (>=) rather than After so equal timestamps resolve toward the
+	// later-scanned record. .After is false on a tie, which would otherwise keep
+	// the earliest (oldest-positioned) origin and contradict "most recent wins".
 	for i := range records {
-		if mostRecent == -1 || records[i].lastSeen.After(records[mostRecent].lastSeen) {
+		if mostRecent == -1 || !records[i].lastSeen.Before(records[mostRecent].lastSeen) {
 			mostRecent = i
 		}
-		if now.Before(records[i].expiry) && (best == -1 || records[i].lastSeen.After(records[best].lastSeen)) {
+		if now.Before(records[i].expiry) && (best == -1 || !records[i].lastSeen.Before(records[best].lastSeen)) {
 			best = i
 		}
 	}
@@ -1066,14 +1069,22 @@ func (cm *Manager) cleanupOldEntries() {
 
 	// Delete old entries
 	for _, ip := range toDelete {
-		delete(cm.ipToHostname, ip)
-		delete(cm.ipToCNAMEOrigins, ip)
-		delete(cm.ipLastSeen, ip)
+		cm.forgetIP(ip)
 	}
 
 	if len(toDelete) > 0 {
 		slog.Info("Cleaned up old DNS cache entries", "count", len(toDelete))
 	}
+}
+
+// forgetIP removes an IP from every per-IP map (the reverse-lookup tuple keyed
+// by IP: ipToHostname, ipToCNAMEOrigins, ipLastSeen). It is the single place
+// that knows the full set, so adding another per-IP map only requires one edit
+// here — callers can't leak an entry by forgetting one map. Must hold cm.mu.
+func (cm *Manager) forgetIP(ip string) {
+	delete(cm.ipToHostname, ip)
+	delete(cm.ipToCNAMEOrigins, ip)
+	delete(cm.ipLastSeen, ip)
 }
 
 // HostnameVerdict is the result of evaluating a hostname against the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,11 +164,11 @@ type Manager struct {
 	config           *FirewallConfig
 	resolvedRules    []ResolvedRule
 	hostnameCache    map[string][]net.IP
-	ipToHostname     map[string]string    // Reverse lookup: IP -> hostname
-	ipToCNAMEChain   map[string][]string  // Reverse lookup: IP -> CNAME chain (origin..target) for derived-allow attribution
-	ipLastSeen       map[string]time.Time // Track when each IP was last seen
-	trackedHostnames map[string]Action    // Track hostnames we have rules for (hostname -> action)
-	maxCacheSize     int                  // Maximum number of IPs to cache
+	ipToHostname     map[string]string              // Reverse lookup: IP -> hostname
+	ipToCNAMEOrigins map[string][]cnameOriginRecord // Reverse lookup: IP -> CNAME chains (one per origin) for derived-allow attribution
+	ipLastSeen       map[string]time.Time           // Track when each IP was last seen
+	trackedHostnames map[string]Action              // Track hostnames we have rules for (hostname -> action)
+	maxCacheSize     int                            // Maximum number of IPs to cache
 }
 
 // NewConfigManager creates a new configuration manager
@@ -176,7 +176,7 @@ func NewConfigManager() *Manager {
 	return &Manager{
 		hostnameCache:    make(map[string][]net.IP),
 		ipToHostname:     make(map[string]string),
-		ipToCNAMEChain:   make(map[string][]string),
+		ipToCNAMEOrigins: make(map[string][]cnameOriginRecord),
 		ipLastSeen:       make(map[string]time.Time),
 		trackedHostnames: make(map[string]Action),
 		maxCacheSize:     10000, // Default max cache size
@@ -934,12 +934,35 @@ func (cm *Manager) UpdateDNSMapping(hostname string, ip string) {
 	}
 }
 
-// RecordCNAMEChain records the CNAME chain (origin..target, ordered) that a
-// derived-allow IP was reached through, so connection events for that IP can be
-// attributed to the origin hostname the user actually allowed rather than the
-// opaque CDN/edge target. Stored lowercase and bounded by the shared ipLastSeen
-// lifecycle (see cleanupOldEntries). A nil/empty chain is ignored.
-func (cm *Manager) RecordCNAMEChain(ip string, chain []string) {
+// cnameOriginRecord is one origin's CNAME chain to a derived-allow IP, kept with
+// freshness so the most recently-chased origin can be chosen at report time and
+// stale ones (no longer chaining here) dropped. A single CDN/edge IP can be
+// reached via the chains of several allowed origins; we retain a bounded,
+// recency-ranked set rather than collapsing to one.
+type cnameOriginRecord struct {
+	chain    []string  // origin..target, origin = chain[0]
+	lastSeen time.Time // when this origin last chained to the IP
+	expiry   time.Time // chain TTL; after this the origin no longer "currently chains here"
+}
+
+// maxCNAMEOriginsPerIP bounds the per-IP origin set. A CDN edge is fronted by
+// few of a user's allowed hostnames in practice, so a small cap is ample; the
+// oldest entry is evicted on overflow.
+const maxCNAMEOriginsPerIP = 8
+
+// cnameOriginFloorTTL is the minimum expiry applied when a response carries a
+// zero/absent TTL, so a TTL-0 CDN answer doesn't make an attribution expire
+// instantly (which would drop us back to the opaque edge name).
+const cnameOriginFloorTTL = 5 * time.Minute
+
+// RecordCNAMEChain records that a derived-allow IP was reached through `chain`
+// (origin..target, ordered), so connection events for that IP can be attributed
+// to the origin hostname the user actually allowed rather than the opaque
+// CDN/edge target. Multiple origins can reach the same IP; each is kept with its
+// recency and `ttl`-derived freshness so LookupCNAMEChain can pick the origin the
+// current request most likely chased. Stored lowercase and bounded by the shared
+// ipLastSeen lifecycle (see cleanupOldEntries). A nil/empty chain is ignored.
+func (cm *Manager) RecordCNAMEChain(ip string, chain []string, ttl time.Duration) {
 	if ip == "" || len(chain) == 0 {
 		return
 	}
@@ -949,26 +972,77 @@ func (cm *Manager) RecordCNAMEChain(ip string, chain []string) {
 		stored[i] = strings.ToLower(h)
 	}
 
+	now := time.Now()
+	if ttl < cnameOriginFloorTTL {
+		ttl = cnameOriginFloorTTL
+	}
+	rec := cnameOriginRecord{chain: stored, lastSeen: now, expiry: now.Add(ttl)}
+	origin := stored[0]
+
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	cm.ipToCNAMEChain[ip] = stored
-	cm.ipLastSeen[ip] = time.Now()
+	records := cm.ipToCNAMEOrigins[ip]
+	// Upsert by origin: a repeat resolution of the same chain refreshes it in
+	// place rather than adding a duplicate.
+	replaced := false
+	for i := range records {
+		if len(records[i].chain) > 0 && records[i].chain[0] == origin {
+			records[i] = rec
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		records = append(records, rec)
+		// Evict the least-recently-seen entry if over the cap.
+		if len(records) > maxCNAMEOriginsPerIP {
+			oldest := 0
+			for i := 1; i < len(records); i++ {
+				if records[i].lastSeen.Before(records[oldest].lastSeen) {
+					oldest = i
+				}
+			}
+			records = append(records[:oldest], records[oldest+1:]...)
+		}
+	}
+	cm.ipToCNAMEOrigins[ip] = records
+	cm.ipLastSeen[ip] = now
 }
 
-// LookupCNAMEChain returns the CNAME chain (origin..target) recorded for a
-// derived-allow IP, or nil if none. The returned slice is a copy so callers
-// can't mutate cache state.
+// LookupCNAMEChain returns the CNAME chain (origin..target) for a derived-allow
+// IP that the current request most likely chased: the most recently-seen origin
+// whose chain has not yet expired ("still currently chains here"). If every
+// recorded origin has expired it falls back to the most recent one so a stale
+// IP still attributes to an allowed host rather than the opaque edge. Returns
+// nil if nothing was recorded. The returned slice is a copy.
 func (cm *Manager) LookupCNAMEChain(ip string) []string {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 
-	chain, ok := cm.ipToCNAMEChain[ip]
-	if !ok {
+	records := cm.ipToCNAMEOrigins[ip]
+	if len(records) == 0 {
 		return nil
 	}
-	out := make([]string, len(chain))
-	copy(out, chain)
+
+	now := time.Now()
+	best := -1       // most-recent non-expired
+	mostRecent := -1 // most-recent overall (fallback when all expired)
+	for i := range records {
+		if mostRecent == -1 || records[i].lastSeen.After(records[mostRecent].lastSeen) {
+			mostRecent = i
+		}
+		if now.Before(records[i].expiry) && (best == -1 || records[i].lastSeen.After(records[best].lastSeen)) {
+			best = i
+		}
+	}
+	pick := best
+	if pick == -1 {
+		pick = mostRecent // all expired → fall back to last-known
+	}
+
+	out := make([]string, len(records[pick].chain))
+	copy(out, records[pick].chain)
 	return out
 }
 
@@ -993,7 +1067,7 @@ func (cm *Manager) cleanupOldEntries() {
 	// Delete old entries
 	for _, ip := range toDelete {
 		delete(cm.ipToHostname, ip)
-		delete(cm.ipToCNAMEChain, ip)
+		delete(cm.ipToCNAMEOrigins, ip)
 		delete(cm.ipLastSeen, ip)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -165,6 +165,7 @@ type Manager struct {
 	resolvedRules    []ResolvedRule
 	hostnameCache    map[string][]net.IP
 	ipToHostname     map[string]string    // Reverse lookup: IP -> hostname
+	ipToCNAMEChain   map[string][]string  // Reverse lookup: IP -> CNAME chain (origin..target) for derived-allow attribution
 	ipLastSeen       map[string]time.Time // Track when each IP was last seen
 	trackedHostnames map[string]Action    // Track hostnames we have rules for (hostname -> action)
 	maxCacheSize     int                  // Maximum number of IPs to cache
@@ -175,6 +176,7 @@ func NewConfigManager() *Manager {
 	return &Manager{
 		hostnameCache:    make(map[string][]net.IP),
 		ipToHostname:     make(map[string]string),
+		ipToCNAMEChain:   make(map[string][]string),
 		ipLastSeen:       make(map[string]time.Time),
 		trackedHostnames: make(map[string]Action),
 		maxCacheSize:     10000, // Default max cache size
@@ -932,6 +934,44 @@ func (cm *Manager) UpdateDNSMapping(hostname string, ip string) {
 	}
 }
 
+// RecordCNAMEChain records the CNAME chain (origin..target, ordered) that a
+// derived-allow IP was reached through, so connection events for that IP can be
+// attributed to the origin hostname the user actually allowed rather than the
+// opaque CDN/edge target. Stored lowercase and bounded by the shared ipLastSeen
+// lifecycle (see cleanupOldEntries). A nil/empty chain is ignored.
+func (cm *Manager) RecordCNAMEChain(ip string, chain []string) {
+	if ip == "" || len(chain) == 0 {
+		return
+	}
+
+	stored := make([]string, len(chain))
+	for i, h := range chain {
+		stored[i] = strings.ToLower(h)
+	}
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.ipToCNAMEChain[ip] = stored
+	cm.ipLastSeen[ip] = time.Now()
+}
+
+// LookupCNAMEChain returns the CNAME chain (origin..target) recorded for a
+// derived-allow IP, or nil if none. The returned slice is a copy so callers
+// can't mutate cache state.
+func (cm *Manager) LookupCNAMEChain(ip string) []string {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	chain, ok := cm.ipToCNAMEChain[ip]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(chain))
+	copy(out, chain)
+	return out
+}
+
 // dnsCacheTTL is how long a DNS reverse mapping is kept before
 // cleanupOldEntries can discard it. Set to a day so containers / long-lived
 // connections aren't reverse-resolved repeatedly. Inlined here because no
@@ -953,6 +993,7 @@ func (cm *Manager) cleanupOldEntries() {
 	// Delete old entries
 	for _, ip := range toDelete {
 		delete(cm.ipToHostname, ip)
+		delete(cm.ipToCNAMEChain, ip)
 		delete(cm.ipLastSeen, ip)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2507,6 +2507,48 @@ func TestUpdateDNSMapping(t *testing.T) {
 	}
 }
 
+// RecordCNAMEChain stores a lowercased copy of the chain keyed by IP and
+// LookupCNAMEChain returns an independent copy. Empty inputs are ignored, and
+// the entry shares the ipLastSeen-based cleanup lifecycle.
+func TestRecordAndLookupCNAMEChain(t *testing.T) {
+	cm := NewConfigManager()
+
+	// nil/empty inputs are no-ops.
+	cm.RecordCNAMEChain("", []string{"a", "b"})
+	cm.RecordCNAMEChain("1.2.3.4", nil)
+	if got := cm.LookupCNAMEChain("1.2.3.4"); got != nil {
+		t.Errorf("empty chain must not be recorded: got %v", got)
+	}
+
+	// Mixed-case chain is stored lowercase.
+	cm.RecordCNAMEChain("23.62.177.200", []string{"WWW.Microsoft.com", "E13678.dscb.AkamaiEdge.net"})
+	got := cm.LookupCNAMEChain("23.62.177.200")
+	want := []string{"www.microsoft.com", "e13678.dscb.akamaiedge.net"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LookupCNAMEChain = %v, want %v", got, want)
+	}
+
+	// Returned slice is a copy — mutating it must not corrupt cache state.
+	got[0] = "tampered"
+	if again := cm.LookupCNAMEChain("23.62.177.200"); again[0] != "www.microsoft.com" {
+		t.Errorf("LookupCNAMEChain must return a copy; cache mutated to %v", again)
+	}
+
+	// Unknown IP → nil.
+	if got := cm.LookupCNAMEChain("9.9.9.9"); got != nil {
+		t.Errorf("unknown IP must return nil, got %v", got)
+	}
+
+	// ipLastSeen is touched so cleanupOldEntries can evict the chain.
+	cm.mu.Lock()
+	cm.ipLastSeen["23.62.177.200"] = time.Now().Add(-2 * dnsCacheTTL)
+	cm.cleanupOldEntries()
+	cm.mu.Unlock()
+	if got := cm.LookupCNAMEChain("23.62.177.200"); got != nil {
+		t.Errorf("stale CNAME chain must be evicted by cleanupOldEntries, got %v", got)
+	}
+}
+
 // =============================================================================
 // Direct tests for internal helpers (Phase 4)
 // =============================================================================

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2514,14 +2514,14 @@ func TestRecordAndLookupCNAMEChain(t *testing.T) {
 	cm := NewConfigManager()
 
 	// nil/empty inputs are no-ops.
-	cm.RecordCNAMEChain("", []string{"a", "b"})
-	cm.RecordCNAMEChain("1.2.3.4", nil)
+	cm.RecordCNAMEChain("", []string{"a", "b"}, time.Hour)
+	cm.RecordCNAMEChain("1.2.3.4", nil, time.Hour)
 	if got := cm.LookupCNAMEChain("1.2.3.4"); got != nil {
 		t.Errorf("empty chain must not be recorded: got %v", got)
 	}
 
 	// Mixed-case chain is stored lowercase.
-	cm.RecordCNAMEChain("23.62.177.200", []string{"WWW.Microsoft.com", "E13678.dscb.AkamaiEdge.net"})
+	cm.RecordCNAMEChain("23.62.177.200", []string{"WWW.Microsoft.com", "E13678.dscb.AkamaiEdge.net"}, time.Hour)
 	got := cm.LookupCNAMEChain("23.62.177.200")
 	want := []string{"www.microsoft.com", "e13678.dscb.akamaiedge.net"}
 	if !reflect.DeepEqual(got, want) {
@@ -2546,6 +2546,90 @@ func TestRecordAndLookupCNAMEChain(t *testing.T) {
 	cm.mu.Unlock()
 	if got := cm.LookupCNAMEChain("23.62.177.200"); got != nil {
 		t.Errorf("stale CNAME chain must be evicted by cleanupOldEntries, got %v", got)
+	}
+}
+
+// When a CDN/edge IP is reachable from several allowed origins, LookupCNAMEChain
+// returns the most recently-seen origin whose chain is still live, falling back
+// to the most recent overall once everything has expired.
+func TestLookupCNAMEChain_MultiOriginRecencyAndExpiry(t *testing.T) {
+	cm := NewConfigManager()
+	const ip = "23.45.137.206"
+	const edge = "e13678.dscb.akamaiedge.net"
+	chainA := []string{"www.microsoft.com", edge}
+	chainB := []string{"login.microsoftonline.com", edge}
+
+	// A then B → B is more recent, so it wins.
+	cm.RecordCNAMEChain(ip, chainA, time.Hour)
+	cm.RecordCNAMEChain(ip, chainB, time.Hour)
+	if got := cm.LookupCNAMEChain(ip); !reflect.DeepEqual(got, chainB) {
+		t.Errorf("most-recent origin must win: got %v, want %v", got, chainB)
+	}
+
+	// Re-resolving A refreshes its recency (upsert in place, no duplicate).
+	cm.RecordCNAMEChain(ip, chainA, time.Hour)
+	if got := cm.LookupCNAMEChain(ip); !reflect.DeepEqual(got, chainA) {
+		t.Errorf("re-resolved origin must win: got %v, want %v", got, chainA)
+	}
+	cm.mu.RLock()
+	n := len(cm.ipToCNAMEOrigins[ip])
+	cm.mu.RUnlock()
+	if n != 2 {
+		t.Errorf("repeat origin must upsert in place: got %d records, want 2", n)
+	}
+
+	// Expire the most-recent origin (A); the still-live B must be chosen even
+	// though it's older. (RecordCNAMEChain floors TTLs, so set expiry directly.)
+	cm.mu.Lock()
+	for i := range cm.ipToCNAMEOrigins[ip] {
+		if cm.ipToCNAMEOrigins[ip][i].chain[0] == "www.microsoft.com" {
+			cm.ipToCNAMEOrigins[ip][i].expiry = time.Now().Add(-time.Minute)
+		}
+	}
+	cm.mu.Unlock()
+	if got := cm.LookupCNAMEChain(ip); !reflect.DeepEqual(got, chainB) {
+		t.Errorf("expired most-recent origin must be skipped: got %v, want %v", got, chainB)
+	}
+
+	// All expired → fall back to the most recent overall (A).
+	cm.mu.Lock()
+	for i := range cm.ipToCNAMEOrigins[ip] {
+		cm.ipToCNAMEOrigins[ip][i].expiry = time.Now().Add(-time.Minute)
+	}
+	cm.mu.Unlock()
+	if got := cm.LookupCNAMEChain(ip); !reflect.DeepEqual(got, chainA) {
+		t.Errorf("all-expired fallback must be the most recent origin: got %v, want %v", got, chainA)
+	}
+}
+
+// The per-IP origin set is bounded; the oldest origin is evicted on overflow
+// while the freshest survives.
+func TestRecordCNAMEChain_CapsOriginsPerIP(t *testing.T) {
+	cm := NewConfigManager()
+	const ip = "203.0.113.7"
+
+	// Distinct origin names a.example.com, b.example.com, … recorded oldest-first.
+	origin := func(i int) string { return string(rune('a'+i)) + ".example.com" }
+	for i := 0; i < maxCNAMEOriginsPerIP+3; i++ {
+		cm.RecordCNAMEChain(ip, []string{origin(i), "edge.cdn.example.net"}, time.Hour)
+	}
+
+	cm.mu.RLock()
+	present := make(map[string]bool, len(cm.ipToCNAMEOrigins[ip]))
+	for _, r := range cm.ipToCNAMEOrigins[ip] {
+		present[r.chain[0]] = true
+	}
+	n := len(cm.ipToCNAMEOrigins[ip])
+	cm.mu.RUnlock()
+
+	if n != maxCNAMEOriginsPerIP {
+		t.Errorf("per-IP origin set must be capped at %d, got %d", maxCNAMEOriginsPerIP, n)
+	}
+	if !present[origin(maxCNAMEOriginsPerIP+2)] {
+		t.Errorf("most-recent origin must survive eviction")
+	}
+	if present[origin(0)] {
+		t.Errorf("oldest origin must be evicted on overflow")
 	}
 }
 

--- a/pkg/dns/lru.go
+++ b/pkg/dns/lru.go
@@ -113,7 +113,12 @@ func (c *lruCache[K, V]) Put(key K, value V, ttl time.Duration) {
 // to the front. compose runs while the cache lock is held, so concurrent Merge
 // calls on the same key accumulate without the lost-update race a separate
 // Get-then-Put would have. If ttl is 0 the entry never expires.
-func (c *lruCache[K, V]) Merge(key K, value V, ttl time.Duration, compose func(existing, incoming V) V) {
+//
+// Returns whether a live existing entry was composed with (true) versus a fresh
+// insert — i.e. an absent key or one treated as absent because it had expired.
+// Lets callers distinguish "refresh" from "first-learn" atomically, without a
+// separate Get that would double-lock and race the Merge.
+func (c *lruCache[K, V]) Merge(key K, value V, ttl time.Duration, compose func(existing, incoming V) V) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -126,13 +131,14 @@ func (c *lruCache[K, V]) Merge(key K, value V, ttl time.Duration, compose func(e
 		e := elem.Value.(*lruEntry[K, V])
 		// Compose only with a live value; an expired entry is treated as
 		// absent so a stale set can't resurrect through the merge.
-		if e.expiry.IsZero() || time.Now().Before(e.expiry) {
+		live := e.expiry.IsZero() || time.Now().Before(e.expiry)
+		if live {
 			value = compose(e.value, value)
 		}
 		c.order.MoveToFront(elem)
 		e.value = value
 		e.expiry = expiry
-		return
+		return live
 	}
 
 	// Evict LRU tail if at capacity (mirrors Put).
@@ -149,6 +155,7 @@ func (c *lruCache[K, V]) Merge(key K, value V, ttl time.Duration, compose func(e
 		expiry: expiry,
 	})
 	c.items[key] = elem
+	return false
 }
 
 // Delete removes a key from the cache.

--- a/pkg/dns/lru_test.go
+++ b/pkg/dns/lru_test.go
@@ -189,6 +189,32 @@ func TestLRUCache_LenIncludesNotYetEvictedExpired(t *testing.T) {
 	assert.Equal(t, 1, c.Len(), "lazy eviction on Get removes expired entry")
 }
 
+// Merge reports whether it composed with a LIVE existing entry: false on a
+// fresh insert or an expired (treated-as-absent) key, true on a live refresh.
+// The compose fn runs only in the live case.
+func TestLRUCache_MergeReportsLiveness(t *testing.T) {
+	c := newLRUCache[string, int](10)
+	sum := func(existing, incoming int) int { return existing + incoming }
+
+	// Absent key → fresh insert, no compose, reports not-existed.
+	assert.False(t, c.Merge("k", 1, time.Minute, sum), "first Merge of absent key must report not-existed")
+	got, _ := c.Get("k")
+	assert.Equal(t, 1, got, "fresh Merge stores the incoming value")
+
+	// Live key → compose, reports existed.
+	assert.True(t, c.Merge("k", 2, time.Minute, sum), "Merge of a live key must report existed")
+	got, _ = c.Get("k")
+	assert.Equal(t, 3, got, "live Merge composes (1+2)")
+
+	// Expired key is treated as absent: no compose, reports not-existed, value
+	// replaced rather than summed.
+	c.Merge("e", 5, 10*time.Millisecond, sum)
+	time.Sleep(20 * time.Millisecond)
+	assert.False(t, c.Merge("e", 7, time.Minute, sum), "Merge of an expired key must report not-existed")
+	got, _ = c.Get("e")
+	assert.Equal(t, 7, got, "expired Merge replaces (not composes) → 7")
+}
+
 // Concurrent Get/Put must not race. Run under `go test -race` to catch any
 // missed locking.
 func TestLRUCache_ConcurrentAccess(t *testing.T) {

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -606,7 +606,10 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 						// Attribute this IP to the origin (derivedChain[0]) so the
 						// connection-event reporter can show the allowed hostname
 						// the user configured, with the CNAME chain as drill-down.
-						s.config.RecordCNAMEChain(ip.String(), derivedChain)
+						// Pass the response TTL so a later request that chased a
+						// different allowed origin to this shared edge wins the
+						// attribution once this one goes stale.
+						s.config.RecordCNAMEChain(ip.String(), derivedChain, time.Duration(ttl)*time.Second)
 					}
 				case !verdict.Matched():
 					// No rules yet, but track that we've seen this hostname
@@ -646,12 +649,15 @@ type derivedAllow struct {
 // mergeDerivedAllow composes an existing cache entry with an incoming one for
 // the same target: allow ports are UNIONed across origins (config.UnionPorts —
 // a target reachable from two allowed hosts on different ports must end up
-// allowed on both), while the chain is kept first-write-wins so attribution is
-// stable. Ports stay authoritative for enforcement; the chain is for display.
+// allowed on both). The chain is kept last-write-wins: when an edge is shared
+// by several allowed origins, the most recently-resolved origin is the one a
+// chain-chasing client is currently following, so it's the best display
+// attribution and the one propagated to the per-IP record (which keeps its own
+// recency-ranked set across origins). Ports stay authoritative for enforcement.
 func mergeDerivedAllow(existing, incoming derivedAllow) derivedAllow {
-	chain := existing.chain
+	chain := incoming.chain
 	if len(chain) == 0 {
-		chain = incoming.chain
+		chain = existing.chain
 	}
 	return derivedAllow{
 		ports: config.UnionPorts(existing.ports, incoming.ports),

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -494,7 +494,8 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// rule-allowed response the origin is the queried name; for a derived
 		// response the chain extends the parent target's stored chain, so
 		// attribution survives a chain split across query round-trips.
-		// mergeDerivedAllow keeps the first chain (stable) while unioning ports.
+		// mergeDerivedAllow keeps the most recently-resolved chain (last-write-
+		// wins) while unioning ports; the per-IP record retains older origins.
 		if s.cnameAllowed != nil && (verdict.HasAllow() || derived) {
 			inheritPorts := derivedPorts
 			path := append([]string{}, derivedChain...)
@@ -512,23 +513,23 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				ttl := time.Duration(derivedCNAMETTL(link.ttl)) * time.Second
 				path = append(path, link.target)
 				chain := append([]string{}, path...)
-				// Log at Info only the first time a target is learned (or re-
-				// learned after expiry); a refresh of an already-known target
-				// drops to Debug so steady-state resolutions stay quiet.
+				// Log a first-learn (or re-learn after expiry) at Info so a
+				// later-blocked edge IP is traceable to its origin; a refresh of
+				// an already-known target drops to Debug so steady-state
+				// resolutions stay quiet.
 				_, known := s.cnameAllowed.Get(link.target)
 				s.cnameAllowed.Merge(link.target, derivedAllow{ports: inheritPorts, chain: chain}, ttl, mergeDerivedAllow)
+				msg, level := "Learned CNAME target", slog.LevelInfo
 				if known {
-					s.logger.Debug("Refreshed CNAME target",
-						"target", link.target, "origin", chain[0], "source", source)
-				} else {
-					s.logger.Info("Learned CNAME target",
-						"target", link.target,
-						"origin", chain[0],
-						"chain", chain,
-						"inherited_ports", inheritPorts,
-						"source", source,
-						"ttl", ttl)
+					msg, level = "Refreshed CNAME target", slog.LevelDebug
 				}
+				s.logger.Log(context.Background(), level, msg,
+					"target", link.target,
+					"origin", chain[0],
+					"chain", chain,
+					"inherited_ports", inheritPorts,
+					"source", source,
+					"ttl", ttl)
 			}
 		}
 

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -60,14 +60,16 @@ type Server struct {
 	dnsCache *lruCache[string, *dnsCacheEntry]
 
 	// CNAME targets learned from allowed responses (LRU with per-entry TTL).
-	// Maps target -> allow ports inherited from the origin rule (nil/empty =
-	// all ports, matching rule semantics). Consulted by BOTH the query filter
-	// (un-REFUSE a direct query for a CNAME target of an allowed host) and IP
-	// enforcement (allow that target's resolved IPs on the inherited ports).
-	// The enforcement use closes the gap where a chain is split across multiple
-	// query round-trips — e.g. CDN-fronted PKI endpoints — so the in-band
-	// "single response carries every hop" assumption no longer holds.
-	cnameAllowed *lruCache[string, []config.Port]
+	// Maps target -> derivedAllow{ports, chain}: the allow ports inherited from
+	// the origin rule (nil/empty = all ports, matching rule semantics) and the
+	// full ordered CNAME chain from the origin down to this target. Consulted by
+	// BOTH the query filter (un-REFUSE a direct query for a CNAME target of an
+	// allowed host) and IP enforcement (allow that target's resolved IPs on the
+	// inherited ports, attributing them to the origin for reporting). The
+	// enforcement use closes the gap where a chain is split across multiple query
+	// round-trips — e.g. CDN-fronted PKI endpoints — so the in-band "single
+	// response carries every hop" assumption no longer holds.
+	cnameAllowed *lruCache[string, derivedAllow]
 
 	// Audit logger for DNS events
 	auditLogger *events.AuditLogger
@@ -100,7 +102,7 @@ func NewServer(cfg *config.Manager, fw firewall.Firewall, upstream, listenAddr s
 		},
 		hostnameIPs:  make(map[string]map[string]bool),
 		dnsCache:     newLRUCache[string, *dnsCacheEntry](10000),
-		cnameAllowed: newLRUCache[string, []config.Port](10000),
+		cnameAllowed: newLRUCache[string, derivedAllow](10000),
 	}
 }
 
@@ -446,10 +448,11 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// (where the denied query is still forwarded and reaches this code).
 		// Any matching rule is authoritative.
 		var derivedPorts []config.Port
+		var derivedChain []string
 		derived := false
 		if !verdict.Matched() && s.cnameAllowed != nil {
-			if ports, ok := s.cnameAllowed.Get(canonicalHostname); ok {
-				derived, derivedPorts = true, ports
+			if entry, ok := s.cnameAllowed.Get(canonicalHostname); ok {
+				derived, derivedPorts, derivedChain = true, entry.ports, entry.chain
 			}
 		}
 
@@ -484,14 +487,48 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// (e.g. one allows 443, another 80) must end up allowed on both, and an
 		// all-ports origin must absorb a port-restricted one. Merge composes
 		// under the cache lock so concurrent resolutions can't drop a port.
+		//
+		// Each target also stores the full ordered CNAME chain from the origin
+		// down to itself (path below), so a connection event for the target's
+		// resolved IPs can be reported under the origin the user allowed. For a
+		// rule-allowed response the origin is the queried name; for a derived
+		// response the chain extends the parent target's stored chain, so
+		// attribution survives a chain split across query round-trips.
+		// mergeDerivedAllow keeps the first chain (stable) while unioning ports.
 		if s.cnameAllowed != nil && (verdict.HasAllow() || derived) {
 			inheritPorts := derivedPorts
+			path := append([]string{}, derivedChain...)
+			// source records WHY the chain is being learned: which allow rule
+			// rooted it, or "derived" when extending a previously-learned chain.
+			// Logged on first-learn so a later-blocked edge IP is traceable back
+			// to the origin (or its absence shows it was never learned at all).
+			source := "derived"
 			if verdict.HasAllow() {
 				inheritPorts = verdict.AllowPorts
+				path = []string{canonicalHostname}
+				source = "rule:" + verdict.AllowRule
 			}
 			for _, link := range cnameChainTargets(canonicalHostname, resp.Answer) {
 				ttl := time.Duration(derivedCNAMETTL(link.ttl)) * time.Second
-				s.cnameAllowed.Merge(link.target, inheritPorts, ttl, config.UnionPorts)
+				path = append(path, link.target)
+				chain := append([]string{}, path...)
+				// Log at Info only the first time a target is learned (or re-
+				// learned after expiry); a refresh of an already-known target
+				// drops to Debug so steady-state resolutions stay quiet.
+				_, known := s.cnameAllowed.Get(link.target)
+				s.cnameAllowed.Merge(link.target, derivedAllow{ports: inheritPorts, chain: chain}, ttl, mergeDerivedAllow)
+				if known {
+					s.logger.Debug("Refreshed CNAME target",
+						"target", link.target, "origin", chain[0], "source", source)
+				} else {
+					s.logger.Info("Learned CNAME target",
+						"target", link.target,
+						"origin", chain[0],
+						"chain", chain,
+						"inherited_ports", inheritPorts,
+						"source", source,
+						"ttl", ttl)
+				}
 			}
 		}
 
@@ -561,10 +598,15 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 					// and the default-action short-circuit.
 					s.logger.Debug("Hostname tracked for BPF update (derived CNAME allow)",
 						"hostname", canonicalHostname,
-						"allow_ports", derivedPorts)
+						"allow_ports", derivedPorts,
+						"cname_chain", derivedChain)
 
 					for _, ip := range ips {
 						s.applyVerdictSide(ip, canonicalHostname, config.ActionAllow, derivedPorts, false)
+						// Attribute this IP to the origin (derivedChain[0]) so the
+						// connection-event reporter can show the allowed hostname
+						// the user configured, with the CNAME chain as drill-down.
+						s.config.RecordCNAMEChain(ip.String(), derivedChain)
 					}
 				case !verdict.Matched():
 					// No rules yet, but track that we've seen this hostname
@@ -589,6 +631,32 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 type cnameLink struct {
 	target string
 	ttl    uint32
+}
+
+// derivedAllow is the cached attribution for a CNAME target learned from an
+// allowed host: the allow ports inherited from the origin rule (nil/empty =
+// all ports) and the full ordered CNAME chain from the origin (chain[0]) down
+// to this target (chain[len-1]). The chain is what lets a connection event be
+// reported under the origin hostname the user actually allowed.
+type derivedAllow struct {
+	ports []config.Port
+	chain []string
+}
+
+// mergeDerivedAllow composes an existing cache entry with an incoming one for
+// the same target: allow ports are UNIONed across origins (config.UnionPorts —
+// a target reachable from two allowed hosts on different ports must end up
+// allowed on both), while the chain is kept first-write-wins so attribution is
+// stable. Ports stay authoritative for enforcement; the chain is for display.
+func mergeDerivedAllow(existing, incoming derivedAllow) derivedAllow {
+	chain := existing.chain
+	if len(chain) == 0 {
+		chain = incoming.chain
+	}
+	return derivedAllow{
+		ports: config.UnionPorts(existing.ports, incoming.ports),
+		chain: chain,
+	}
 }
 
 // cnameChainTargets walks the CNAME chain in answers starting from qname

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -597,20 +597,29 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 					// variant PKI, dynamic edge labels) is enforced, not just
 					// un-REFUSED. applyVerdictSide keeps the CIDR-conflict check
 					// and the default-action short-circuit.
+					// The A/AAAA records belong to the FINAL CNAME target, which
+					// may chain onward from the queried name within this same
+					// response; extend so the recorded drill-down reaches the
+					// actual edge instead of stopping at the queried name.
+					recordChain := append([]string{}, derivedChain...)
+					for _, link := range cnameChainTargets(canonicalHostname, resp.Answer) {
+						recordChain = append(recordChain, link.target)
+					}
+
 					s.logger.Debug("Hostname tracked for BPF update (derived CNAME allow)",
 						"hostname", canonicalHostname,
 						"allow_ports", derivedPorts,
-						"cname_chain", derivedChain)
+						"cname_chain", recordChain)
 
 					for _, ip := range ips {
 						s.applyVerdictSide(ip, canonicalHostname, config.ActionAllow, derivedPorts, false)
-						// Attribute this IP to the origin (derivedChain[0]) so the
+						// Attribute this IP to the origin (recordChain[0]) so the
 						// connection-event reporter can show the allowed hostname
 						// the user configured, with the CNAME chain as drill-down.
 						// Pass the response TTL so a later request that chased a
 						// different allowed origin to this shared edge wins the
 						// attribution once this one goes stale.
-						s.config.RecordCNAMEChain(ip.String(), derivedChain, time.Duration(ttl)*time.Second)
+						s.config.RecordCNAMEChain(ip.String(), recordChain, time.Duration(ttl)*time.Second)
 					}
 				case !verdict.Matched():
 					// No rules yet, but track that we've seen this hostname

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -516,11 +516,11 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				// Log a first-learn (or re-learn after expiry) at Info so a
 				// later-blocked edge IP is traceable to its origin; a refresh of
 				// an already-known target drops to Debug so steady-state
-				// resolutions stay quiet.
-				_, known := s.cnameAllowed.Get(link.target)
-				s.cnameAllowed.Merge(link.target, derivedAllow{ports: inheritPorts, chain: chain}, ttl, mergeDerivedAllow)
+				// resolutions stay quiet. Merge reports liveness atomically, so
+				// no separate Get is needed.
+				existed := s.cnameAllowed.Merge(link.target, derivedAllow{ports: inheritPorts, chain: chain}, ttl, mergeDerivedAllow)
 				msg, level := "Learned CNAME target", slog.LevelInfo
-				if known {
+				if existed {
 					msg, level = "Refreshed CNAME target", slog.LevelDebug
 				}
 				s.logger.Log(context.Background(), level, msg,

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1372,9 +1372,9 @@ func TestIsQueryAllowed_CNAMEDerived(t *testing.T) {
 				config:        cfg,
 				filterQueries: true,
 				logger:        slog.Default(),
-				cnameAllowed:  newLRUCache[string, []config.Port](10000),
+				cnameAllowed:  newLRUCache[string, derivedAllow](10000),
 			}
-			server.cnameAllowed.Put(strings.ToLower(tt.derived), nil, tt.derivedTTL)
+			server.cnameAllowed.Put(strings.ToLower(tt.derived), derivedAllow{}, tt.derivedTTL)
 			if tt.derivedTTL == time.Nanosecond {
 				time.Sleep(time.Millisecond) // let the entry lazily expire
 			}
@@ -1400,7 +1400,7 @@ func newTestServer(t *testing.T, cfg *config.Manager, fw firewall.Firewall) *Ser
 		client:       &dns.Client{Timeout: 5 * time.Second},
 		hostnameIPs:  make(map[string]map[string]bool),
 		dnsCache:     newLRUCache[string, *dnsCacheEntry](10000),
-		cnameAllowed: newLRUCache[string, []config.Port](10000),
+		cnameAllowed: newLRUCache[string, derivedAllow](10000),
 	}
 }
 
@@ -2180,9 +2180,10 @@ func TestHandleDNSQuery_DerivedResponseLearnsTransitively(t *testing.T) {
 	// hop1 was already learned as a CNAME target of an allowed origin (all
 	// ports). A fresh query for it now returns the Cloudflare variant that
 	// chains onward to hop2 before its A record.
+	const origin = "ocsp.digicert.com"
 	const hop1 = "mpki-ocsp.digicert.com"
 	const hop2 = "mpki-ocsp.digicert.com.cdn.cloudflare.net"
-	server.cnameAllowed.Put(hop1, nil, 5*time.Minute)
+	server.cnameAllowed.Put(hop1, derivedAllow{chain: []string{origin, hop1}}, 5*time.Minute)
 
 	resp := makeCNAMEResponse(hop1+".", []string{hop2}, "104.18.38.233")
 	seedCachedResponse(server, hop1+".", resp)
@@ -2196,8 +2197,10 @@ func TestHandleDNSQuery_DerivedResponseLearnsTransitively(t *testing.T) {
 	server.handleDNSQuery(w, q)
 
 	mockFw.AssertExpectations(t)
-	_, ok := server.cnameAllowed.Get(hop2)
+	entry, ok := server.cnameAllowed.Get(hop2)
 	assert.True(t, ok, "onward hop must be learned from a derived-allowed response")
+	assert.Equal(t, []string{origin, hop1, hop2}, entry.chain,
+		"transitively-learned hop must extend the parent's chain so attribution stays rooted at the origin")
 	assert.True(t, server.isQueryAllowed(hop2, dns.TypeA),
 		"transitively-learned hop should be directly queryable")
 }
@@ -2324,7 +2327,7 @@ func TestHandleDNSQuery_DeniedTargetDoesNotDeriveOrLearn(t *testing.T) {
 	const denied = "denied.cdn.example.net"
 	const onward = "onward.cdn.example.net"
 	// Pre-seed as if it had been learned as a CNAME target of an allowed host.
-	server.cnameAllowed.Put(denied, nil, 5*time.Minute)
+	server.cnameAllowed.Put(denied, derivedAllow{}, 5*time.Minute)
 
 	// Its response chains onward and carries an A record. No AddIP is expected:
 	// the deny side equals the default action and short-circuits, and the

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -2203,6 +2203,10 @@ func TestHandleDNSQuery_DerivedResponseLearnsTransitively(t *testing.T) {
 		"transitively-learned hop must extend the parent's chain so attribution stays rooted at the origin")
 	assert.True(t, server.isQueryAllowed(hop2, dns.TypeA),
 		"transitively-learned hop should be directly queryable")
+	// The A record belongs to hop2, so the per-IP attribution must reach the
+	// final target, not stop one hop short at the queried name (hop1).
+	assert.Equal(t, []string{origin, hop1, hop2}, cfg.LookupCNAMEChain("104.18.38.233"),
+		"recorded chain must reach the response's final CNAME target")
 }
 
 // The enforcement path is independent of query filtering. Even with filtering

--- a/pkg/events/audit.go
+++ b/pkg/events/audit.go
@@ -56,9 +56,9 @@ type AuditEvent struct {
 	PID             uint32         `json:"pid,omitempty"`
 	MatchedRule     string         `json:"matched_rule,omitempty"`
 	AutoAllowedType string         `json:"auto_allowed_type,omitempty"`
-	CNAMETarget     []string       `json:"cname_target,omitempty"` // CNAME chain origin..target when DstHostname was reached via a CNAME of an allowed host
-	WouldDeny       bool           `json:"would_deny"`             // true in audit mode (would have been denied)
-	Blocked         bool           `json:"blocked"`                // true in enforce mode (actually blocked)
+	CNAMEChain      []string       `json:"cname_chain,omitempty"` // CNAME chain origin..target when DstHostname was reached via a CNAME of an allowed host
+	WouldDeny       bool           `json:"would_deny"`            // true in audit mode (would have been denied)
+	Blocked         bool           `json:"blocked"`               // true in enforce mode (actually blocked)
 }
 
 // AuditLogger writes audit events to a JSON file (one event per line)
@@ -133,7 +133,7 @@ func (a *AuditLogger) LogConnectionBlocked(srcIP, dstIP, hostname string, dstPor
 		Protocol:    protocol,
 		Process:     process,
 		PID:         pid,
-		CNAMETarget: cnameChain,
+		CNAMEChain:  cnameChain,
 	})
 }
 
@@ -156,7 +156,7 @@ func (a *AuditLogger) LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRu
 		Process:     process,
 		PID:         pid,
 		MatchedRule: matchedRule,
-		CNAMETarget: cnameChain,
+		CNAMEChain:  cnameChain,
 	})
 }
 
@@ -177,7 +177,7 @@ func (a *AuditLogger) LogConnectionAllowed(srcIP, dstIP, hostname string, dstPor
 		Process:         process,
 		PID:             pid,
 		AutoAllowedType: autoAllowedType,
-		CNAMETarget:     cnameChain,
+		CNAMEChain:      cnameChain,
 	})
 }
 
@@ -192,7 +192,7 @@ func (a *AuditLogger) LogProtocolBlocked(srcIP, dstIP, hostname, protocol, proce
 		Protocol:    protocol,
 		Process:     process,
 		PID:         pid,
-		CNAMETarget: cnameChain,
+		CNAMEChain:  cnameChain,
 	})
 }
 

--- a/pkg/events/audit.go
+++ b/pkg/events/audit.go
@@ -56,8 +56,9 @@ type AuditEvent struct {
 	PID             uint32         `json:"pid,omitempty"`
 	MatchedRule     string         `json:"matched_rule,omitempty"`
 	AutoAllowedType string         `json:"auto_allowed_type,omitempty"`
-	WouldDeny       bool           `json:"would_deny"` // true in audit mode (would have been denied)
-	Blocked         bool           `json:"blocked"`    // true in enforce mode (actually blocked)
+	CNAMETarget     []string       `json:"cname_target,omitempty"` // CNAME chain origin..target when DstHostname was reached via a CNAME of an allowed host
+	WouldDeny       bool           `json:"would_deny"`             // true in audit mode (would have been denied)
+	Blocked         bool           `json:"blocked"`                // true in enforce mode (actually blocked)
 }
 
 // AuditLogger writes audit events to a JSON file (one event per line)
@@ -121,7 +122,7 @@ func (a *AuditLogger) LogEvent(event AuditEvent) error {
 // protocol of the dropped packet (typically "TCP" or "UDP" — see
 // getProtocolName); the field is shipped to the summary backend and rendered
 // in the UI's Baseline Entries table, so a real value beats a generic literal.
-func (a *AuditLogger) LogConnectionBlocked(srcIP, dstIP, hostname string, dstPort uint16, process string, pid uint32, protocol string) error {
+func (a *AuditLogger) LogConnectionBlocked(srcIP, dstIP, hostname string, dstPort uint16, process string, pid uint32, protocol string, cnameChain []string) error {
 	return a.LogEvent(AuditEvent{
 		Timestamp:   time.Now(),
 		EventType:   EventConnectionBlocked,
@@ -132,6 +133,7 @@ func (a *AuditLogger) LogConnectionBlocked(srcIP, dstIP, hostname string, dstPor
 		Protocol:    protocol,
 		Process:     process,
 		PID:         pid,
+		CNAMETarget: cnameChain,
 	})
 }
 
@@ -142,7 +144,7 @@ func (a *AuditLogger) LogConnectionBlocked(srcIP, dstIP, hostname string, dstPor
 // `matchedRule` is the rule's Value (pattern string for glob rules, configured
 // hostname for plain rules), which can differ from the resolved DstHostname
 // (e.g. rule `*.compute-1.amazonaws.com` matching `ec2-1-2-3-4.compute-1...`).
-func (a *AuditLogger) LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRule string, dstPort uint16, process string, pid uint32, protocol string) error {
+func (a *AuditLogger) LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRule string, dstPort uint16, process string, pid uint32, protocol string, cnameChain []string) error {
 	return a.LogEvent(AuditEvent{
 		Timestamp:   time.Now(),
 		EventType:   EventConnectionLateAllowed,
@@ -154,6 +156,7 @@ func (a *AuditLogger) LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRu
 		Process:     process,
 		PID:         pid,
 		MatchedRule: matchedRule,
+		CNAMETarget: cnameChain,
 	})
 }
 
@@ -162,7 +165,7 @@ func (a *AuditLogger) LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRu
 // getProtocolName); the field is shipped to the summary backend and feeds
 // the dedup key, so a real value beats a hardcoded literal (auto-allowed DNS
 // on :53 is the canonical UDP example).
-func (a *AuditLogger) LogConnectionAllowed(srcIP, dstIP, hostname string, dstPort uint16, process string, pid uint32, autoAllowedType, protocol string) error {
+func (a *AuditLogger) LogConnectionAllowed(srcIP, dstIP, hostname string, dstPort uint16, process string, pid uint32, autoAllowedType, protocol string, cnameChain []string) error {
 	return a.LogEvent(AuditEvent{
 		Timestamp:       time.Now(),
 		EventType:       EventConnectionAllowed,
@@ -174,11 +177,12 @@ func (a *AuditLogger) LogConnectionAllowed(srcIP, dstIP, hostname string, dstPor
 		Process:         process,
 		PID:             pid,
 		AutoAllowedType: autoAllowedType,
+		CNAMETarget:     cnameChain,
 	})
 }
 
 // LogProtocolBlocked logs a blocked protocol event
-func (a *AuditLogger) LogProtocolBlocked(srcIP, dstIP, hostname, protocol, process string, pid uint32) error {
+func (a *AuditLogger) LogProtocolBlocked(srcIP, dstIP, hostname, protocol, process string, pid uint32, cnameChain []string) error {
 	return a.LogEvent(AuditEvent{
 		Timestamp:   time.Now(),
 		EventType:   EventProtocolBlocked,
@@ -188,6 +192,7 @@ func (a *AuditLogger) LogProtocolBlocked(srcIP, dstIP, hostname, protocol, proce
 		Protocol:    protocol,
 		Process:     process,
 		PID:         pid,
+		CNAMETarget: cnameChain,
 	})
 }
 

--- a/pkg/events/audit_test.go
+++ b/pkg/events/audit_test.go
@@ -50,7 +50,7 @@ func TestAuditLogger_EnforceMode(t *testing.T) {
 	require.NoError(t, err)
 	defer logger.Close()
 
-	err = logger.LogConnectionBlocked("10.0.0.1", "93.184.216.34", "example.com", 443, "curl", 1234, "TCP")
+	err = logger.LogConnectionBlocked("10.0.0.1", "93.184.216.34", "example.com", 443, "curl", 1234, "TCP", nil)
 	require.NoError(t, err)
 
 	events := readAuditEvents(t, path)
@@ -73,7 +73,7 @@ func TestAuditLogger_AuditMode(t *testing.T) {
 	require.NoError(t, err)
 	defer logger.Close()
 
-	err = logger.LogConnectionBlocked("10.0.0.1", "93.184.216.34", "example.com", 443, "curl", 1234, "UDP")
+	err = logger.LogConnectionBlocked("10.0.0.1", "93.184.216.34", "example.com", 443, "curl", 1234, "UDP", nil)
 	require.NoError(t, err)
 
 	events := readAuditEvents(t, path)
@@ -91,7 +91,7 @@ func TestAuditLogger_ConnectionLateAllowed(t *testing.T) {
 
 	// Pattern rule ("*.example.com") matched the resolved subdomain
 	// ("api.example.com") — MatchedRule must be the rule, not the hostname.
-	err = logger.LogConnectionLateAllowed("10.0.0.1", "93.184.216.34", "api.example.com", "*.example.com", 443, "curl", 1234, "TCP")
+	err = logger.LogConnectionLateAllowed("10.0.0.1", "93.184.216.34", "api.example.com", "*.example.com", 443, "curl", 1234, "TCP", nil)
 	require.NoError(t, err)
 
 	events := readAuditEvents(t, path)
@@ -112,7 +112,7 @@ func TestAuditLogger_AllowedEventDoesNotOverrideFlags(t *testing.T) {
 	require.NoError(t, err)
 	defer logger.Close()
 
-	err = logger.LogConnectionAllowed("10.0.0.1", "93.184.216.34", "example.com", 443, "curl", 1, "", "TCP")
+	err = logger.LogConnectionAllowed("10.0.0.1", "93.184.216.34", "example.com", 443, "curl", 1, "", "TCP", nil)
 	require.NoError(t, err)
 
 	events := readAuditEvents(t, path)
@@ -133,7 +133,7 @@ func TestAuditLogger_AllowedEventAutoAllowedType(t *testing.T) {
 
 	// DNS allow on :53 — the canonical UDP allow case. Was logged as "TCP"
 	// before the protocol parameter was threaded through.
-	err = logger.LogConnectionAllowed("10.0.0.1", "8.8.8.8", "", 53, "dns", 1, "dns", "UDP")
+	err = logger.LogConnectionAllowed("10.0.0.1", "8.8.8.8", "", 53, "dns", 1, "dns", "UDP", nil)
 	require.NoError(t, err)
 
 	events := readAuditEvents(t, path)
@@ -193,7 +193,7 @@ func TestAuditLogger_ProtocolBlocked(t *testing.T) {
 	require.NoError(t, err)
 	defer logger.Close()
 
-	err = logger.LogProtocolBlocked("10.0.0.1", "10.0.0.2", "", "ICMP", "ping", 99)
+	err = logger.LogProtocolBlocked("10.0.0.1", "10.0.0.2", "", "ICMP", "ping", 99, nil)
 	require.NoError(t, err)
 
 	events := readAuditEvents(t, path)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -516,12 +516,12 @@ func cnameLogAttr(chain []string) []any {
 	if len(chain) == 0 {
 		return nil
 	}
-	return []any{"cname_target", strings.Join(chain, " → ")}
+	return []any{"cname_chain", strings.Join(chain, " → ")}
 }
 
 // logConnEvent emits a connection event at Info, appending the CNAME drill-down
 // attribute when present. Centralizes the append/cnameLogAttr wiring so every
-// event type surfaces cname_target consistently.
+// event type surfaces cname_chain consistently.
 func logConnEvent(logger *slog.Logger, msg string, cnameChain []string, attrs ...any) {
 	logger.Info(msg, append(attrs, cnameLogAttr(cnameChain)...)...)
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -310,6 +310,21 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 		}
 	}
 
+	// CNAME attribution: if this IP was reached as a CNAME target of an allowed
+	// host (derived-allow enforcement recorded the chain — see
+	// Manager.RecordCNAMEChain), report the connection under the origin hostname
+	// the user actually allowed (chain[0]) and surface the full chain as a
+	// drill-down field. Done before the late-allow block so a blocked derived
+	// connection on a non-inherited port also attributes to the origin and runs
+	// the late-allow check against the origin's rule. The recorded target equals
+	// the resolved `hostname`, so the chain[0] != hostname guard skips the
+	// no-op self case.
+	var cnameChain []string
+	if chain := configMgr.LookupCNAMEChain(dstIP); len(chain) > 0 && chain[0] != "" && chain[0] != hostname {
+		cnameChain = chain
+		hostname = chain[0]
+	}
+
 	// Late-add: if a blocked event resolves to a hostname that's actually
 	// allowed (e.g. process bypassed our DNS proxy with a cached IP), open the
 	// firewall so future retries succeed. Only treat the triggering connection
@@ -411,23 +426,24 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 		autoAllowedType := string(configMgr.GetAutoAllowedType(dstIP, event.DstPort, eventProto, hostname))
 
 		// Allowed TCP SYN connection
-		logger.Info("Connection allowed",
+		logger.Info("Connection allowed", append([]any{
 			"src", fmt.Sprintf("%s:%d", srcIP, event.SrcPort),
 			"dst", displayHostname,
 			"dst_ip", dstIP,
 			"dst_port", event.DstPort,
 			"process", comm,
-			"pid", pid)
+			"pid", pid,
+		}, cnameLogAttr(cnameChain)...)...)
 
 		if auditLogger != nil {
-			if err := auditLogger.LogConnectionAllowed(srcIP, dstIP, hostname, event.DstPort, comm, pid, autoAllowedType, getProtocolName(event.IpProto)); err != nil {
+			if err := auditLogger.LogConnectionAllowed(srcIP, dstIP, hostname, event.DstPort, comm, pid, autoAllowedType, getProtocolName(event.IpProto), cnameChain); err != nil {
 				logger.Error("Failed to write audit log", "error", err)
 			}
 		}
 	} else if event.SrcPort == 0 && event.DstPort < 256 {
 		// Non-TCP/UDP protocol block — dst_port contains the protocol number
 		protocolName := getProtocolName(uint8(event.DstPort))
-		logger.Info("Protocol blocked",
+		logger.Info("Protocol blocked", append([]any{
 			"src", srcIP,
 			"dst", displayHostname,
 			"dst_ip", dstIP,
@@ -435,11 +451,12 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 			"protocol_num", event.DstPort,
 			"process", comm,
 			"pid", pid,
-			"timestamp", time.Now().Format("2006-01-02 15:04:05"))
+			"timestamp", time.Now().Format("2006-01-02 15:04:05"),
+		}, cnameLogAttr(cnameChain)...)...)
 
 		// Log to audit file if configured
 		if auditLogger != nil {
-			if err := auditLogger.LogProtocolBlocked(srcIP, dstIP, hostname, protocolName, comm, pid); err != nil {
+			if err := auditLogger.LogProtocolBlocked(srcIP, dstIP, hostname, protocolName, comm, pid, cnameChain); err != nil {
 				logger.Error("Failed to write audit log", "error", err)
 			}
 		}
@@ -453,34 +470,36 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 		// and skip the block notification. matchedRule is the rule's Value
 		// (pattern string for glob rules, configured hostname for plain rules) —
 		// distinct from displayHostname, which is what was actually resolved.
-		logger.Info("Connection late-allowed",
+		logger.Info("Connection late-allowed", append([]any{
 			"src", fmt.Sprintf("%s:%d", srcIP, event.SrcPort),
 			"dst", displayHostname,
 			"dst_ip", dstIP,
 			"dst_port", event.DstPort,
 			"process", comm,
 			"pid", pid,
-			"matched_rule", matchedRule)
+			"matched_rule", matchedRule,
+		}, cnameLogAttr(cnameChain)...)...)
 
 		if auditLogger != nil {
-			if err := auditLogger.LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRule, event.DstPort, comm, pid, getProtocolName(event.IpProto)); err != nil {
+			if err := auditLogger.LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRule, event.DstPort, comm, pid, getProtocolName(event.IpProto), cnameChain); err != nil {
 				logger.Error("Failed to write audit log", "error", err)
 			}
 		}
 	} else {
 		// Blocked TCP SYN or UDP connection
-		logger.Info("Connection blocked",
+		logger.Info("Connection blocked", append([]any{
 			"src", fmt.Sprintf("%s:%d", srcIP, event.SrcPort),
 			"dst", displayHostname,
 			"dst_ip", dstIP,
 			"dst_port", event.DstPort,
 			"process", comm,
 			"pid", pid,
-			"timestamp", time.Now().Format("2006-01-02 15:04:05"))
+			"timestamp", time.Now().Format("2006-01-02 15:04:05"),
+		}, cnameLogAttr(cnameChain)...)...)
 
 		// Log to audit file if configured
 		if auditLogger != nil {
-			if err := auditLogger.LogConnectionBlocked(srcIP, dstIP, hostname, event.DstPort, comm, pid, getProtocolName(event.IpProto)); err != nil {
+			if err := auditLogger.LogConnectionBlocked(srcIP, dstIP, hostname, event.DstPort, comm, pid, getProtocolName(event.IpProto), cnameChain); err != nil {
 				logger.Error("Failed to write audit log", "error", err)
 			}
 		}
@@ -490,6 +509,16 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 			notificationTracker.SendNotification(hostname, dstIP, event.DstPort)
 		}
 	}
+}
+
+// cnameLogAttr returns the slog key/value pair surfacing the CNAME drill-down
+// chain (origin → … → target) for a derived-allow connection, or nil when there
+// is no chain so normal connection events aren't annotated.
+func cnameLogAttr(chain []string) []any {
+	if len(chain) == 0 {
+		return nil
+	}
+	return []any{"cname_target", strings.Join(chain, " → ")}
 }
 
 // ProcessBlockedEvents processes blocked connection events

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -314,13 +314,15 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 	// host (derived-allow enforcement recorded the chain — see
 	// Manager.RecordCNAMEChain), report the connection under the origin hostname
 	// the user actually allowed (chain[0]) and surface the full chain as a
-	// drill-down field. Done before the late-allow block so a blocked derived
-	// connection on a non-inherited port also attributes to the origin and runs
-	// the late-allow check against the origin's rule. The recorded target equals
-	// the resolved `hostname`, so the chain[0] != hostname guard skips the
-	// no-op self case.
+	// drill-down field. For an edge IP shared by several allowed origins,
+	// LookupCNAMEChain returns the most recently-resolved one. Done before the
+	// late-allow block so a blocked derived connection on a non-inherited port
+	// also attributes to the origin and runs the late-allow check against the
+	// origin's rule. Setting hostname = chain[0] is a no-op when the resolved
+	// hostname already is the origin (e.g. the IP was later re-mapped in-band),
+	// but we still attach the chain so the drill-down isn't dropped.
 	var cnameChain []string
-	if chain := configMgr.LookupCNAMEChain(dstIP); len(chain) > 0 && chain[0] != "" && chain[0] != hostname {
+	if chain := configMgr.LookupCNAMEChain(dstIP); len(chain) > 0 && chain[0] != "" {
 		cnameChain = chain
 		hostname = chain[0]
 	}
@@ -510,13 +512,15 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 }
 
 // cnameLogAttr returns the slog key/value pair surfacing the CNAME drill-down
-// chain (origin → … → target) for a derived-allow connection, or nil when there
-// is no chain so normal connection events aren't annotated.
+// chain (origin..target) for a derived-allow connection, or nil when there is no
+// chain so normal connection events aren't annotated. The chain is passed as a
+// []string so the live log carries the same shape as the audit/proto field
+// rather than a pre-joined string.
 func cnameLogAttr(chain []string) []any {
 	if len(chain) == 0 {
 		return nil
 	}
-	return []any{"cname_chain", strings.Join(chain, " → ")}
+	return []any{"cname_chain", chain}
 }
 
 // logConnEvent emits a connection event at Info, appending the CNAME drill-down

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -426,14 +426,13 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 		autoAllowedType := string(configMgr.GetAutoAllowedType(dstIP, event.DstPort, eventProto, hostname))
 
 		// Allowed TCP SYN connection
-		logger.Info("Connection allowed", append([]any{
+		logConnEvent(logger, "Connection allowed", cnameChain,
 			"src", fmt.Sprintf("%s:%d", srcIP, event.SrcPort),
 			"dst", displayHostname,
 			"dst_ip", dstIP,
 			"dst_port", event.DstPort,
 			"process", comm,
-			"pid", pid,
-		}, cnameLogAttr(cnameChain)...)...)
+			"pid", pid)
 
 		if auditLogger != nil {
 			if err := auditLogger.LogConnectionAllowed(srcIP, dstIP, hostname, event.DstPort, comm, pid, autoAllowedType, getProtocolName(event.IpProto), cnameChain); err != nil {
@@ -443,7 +442,7 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 	} else if event.SrcPort == 0 && event.DstPort < 256 {
 		// Non-TCP/UDP protocol block — dst_port contains the protocol number
 		protocolName := getProtocolName(uint8(event.DstPort))
-		logger.Info("Protocol blocked", append([]any{
+		logConnEvent(logger, "Protocol blocked", cnameChain,
 			"src", srcIP,
 			"dst", displayHostname,
 			"dst_ip", dstIP,
@@ -451,8 +450,7 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 			"protocol_num", event.DstPort,
 			"process", comm,
 			"pid", pid,
-			"timestamp", time.Now().Format("2006-01-02 15:04:05"),
-		}, cnameLogAttr(cnameChain)...)...)
+			"timestamp", time.Now().Format("2006-01-02 15:04:05"))
 
 		// Log to audit file if configured
 		if auditLogger != nil {
@@ -469,16 +467,17 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 		// Policy outcome is allow (the retry will succeed), so log accordingly
 		// and skip the block notification. matchedRule is the rule's Value
 		// (pattern string for glob rules, configured hostname for plain rules) —
-		// distinct from displayHostname, which is what was actually resolved.
-		logger.Info("Connection late-allowed", append([]any{
+		// distinct from displayHostname, which is the reported destination: the
+		// CNAME origin when this IP was reached via an allowed host's chain,
+		// otherwise the resolved hostname.
+		logConnEvent(logger, "Connection late-allowed", cnameChain,
 			"src", fmt.Sprintf("%s:%d", srcIP, event.SrcPort),
 			"dst", displayHostname,
 			"dst_ip", dstIP,
 			"dst_port", event.DstPort,
 			"process", comm,
 			"pid", pid,
-			"matched_rule", matchedRule,
-		}, cnameLogAttr(cnameChain)...)...)
+			"matched_rule", matchedRule)
 
 		if auditLogger != nil {
 			if err := auditLogger.LogConnectionLateAllowed(srcIP, dstIP, hostname, matchedRule, event.DstPort, comm, pid, getProtocolName(event.IpProto), cnameChain); err != nil {
@@ -487,15 +486,14 @@ func processEvent(raw []byte, configMgr *config.Manager, notificationTracker *No
 		}
 	} else {
 		// Blocked TCP SYN or UDP connection
-		logger.Info("Connection blocked", append([]any{
+		logConnEvent(logger, "Connection blocked", cnameChain,
 			"src", fmt.Sprintf("%s:%d", srcIP, event.SrcPort),
 			"dst", displayHostname,
 			"dst_ip", dstIP,
 			"dst_port", event.DstPort,
 			"process", comm,
 			"pid", pid,
-			"timestamp", time.Now().Format("2006-01-02 15:04:05"),
-		}, cnameLogAttr(cnameChain)...)...)
+			"timestamp", time.Now().Format("2006-01-02 15:04:05"))
 
 		// Log to audit file if configured
 		if auditLogger != nil {
@@ -519,6 +517,13 @@ func cnameLogAttr(chain []string) []any {
 		return nil
 	}
 	return []any{"cname_target", strings.Join(chain, " → ")}
+}
+
+// logConnEvent emits a connection event at Info, appending the CNAME drill-down
+// attribute when present. Centralizes the append/cnameLogAttr wiring so every
+// event type surfaces cname_target consistently.
+func logConnEvent(logger *slog.Logger, msg string, cnameChain []string, attrs ...any) {
+	logger.Info(msg, append(attrs, cnameLogAttr(cnameChain)...)...)
 }
 
 // ProcessBlockedEvents processes blocked connection events

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -842,6 +842,104 @@ func TestProcessEvent_BlockedNoMatchStillLogsBlocked(t *testing.T) {
 	assert.Len(t, smClient.calls, 1, "notification must fire for genuine blocks")
 }
 
+// TestProcessEvent_CNAMEDerivedAttributesToOrigin covers the reporting fix for
+// transparent CNAME support: a connection to a CNAME target's IP (the IP maps
+// to the opaque edge name) must be reported under the origin hostname the user
+// allowed, with the full chain surfaced as the cname_target drill-down field.
+func TestProcessEvent_CNAMEDerivedAttributesToOrigin(t *testing.T) {
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	auditLogger, err := NewAuditLogger(auditPath, false)
+	require.NoError(t, err)
+	defer auditLogger.Close()
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "www.microsoft.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	// The derived edge IP maps to the CNAME target (what LookupHostnameByIP
+	// returns today), and the derived-allow enforcement recorded its chain.
+	const edge = "e13678.dscb.akamaiedge.net"
+	chain := []string{"www.microsoft.com", edge}
+	cm.UpdateDNSMapping(edge, "23.62.177.200")
+	cm.RecordCNAMEChain("23.62.177.200", chain)
+
+	raw := makeBpfEvent(BpfBlockedEvent{
+		IpVersion: 4,
+		Allowed:   1,
+		IpProto:   unix.IPPROTO_TCP,
+		SrcIp:     ipv4ToUint32("10.0.0.1"),
+		DstIp:     ipv4ToUint32("23.62.177.200"),
+		SrcPort:   54321,
+		DstPort:   443,
+	})
+
+	reverseDNSMu.Lock()
+	reverseDNSCache = make(map[string]time.Time)
+	reverseDNSMu.Unlock()
+
+	processEvent(raw, cm, nil, auditLogger, nil, newTestLogger())
+
+	events := readAuditEvents(t, auditPath)
+	require.Len(t, events, 1)
+	assert.Equal(t, EventConnectionAllowed, events[0].EventType)
+	assert.Equal(t, "www.microsoft.com", events[0].DstHostname,
+		"event must be attributed to the origin the user allowed, not the CNAME edge")
+	assert.Equal(t, chain, events[0].CNAMETarget,
+		"the full CNAME chain must be surfaced as the drill-down field")
+}
+
+// TestProcessEvent_CNAMEDerivedBlockedAttributesToOrigin checks the same
+// origin attribution + chain surfacing on the blocked path: a derived edge IP
+// hit on a port outside the origin rule's allow set (here the rule allows only
+// :443, the connection hits :8080) must stay blocked AND report under the
+// origin — the swap runs before the late-allow check so the origin's rule is
+// the one consulted.
+func TestProcessEvent_CNAMEDerivedBlockedAttributesToOrigin(t *testing.T) {
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	auditLogger, err := NewAuditLogger(auditPath, false)
+	require.NoError(t, err)
+	defer auditLogger.Close()
+
+	cm := config.NewConfigManager()
+	require.NoError(t, cm.LoadConfigFromRules([]config.Rule{
+		{
+			Type: config.RuleTypeHostname, Value: "www.microsoft.com",
+			Ports: []config.Port{{Port: 443, Protocol: config.ProtocolTCP}}, Action: config.ActionAllow,
+		},
+	}, config.ActionDeny))
+
+	const edge = "e13678.dscb.akamaiedge.net"
+	chain := []string{"www.microsoft.com", edge}
+	cm.UpdateDNSMapping(edge, "23.62.177.200")
+	cm.RecordCNAMEChain("23.62.177.200", chain)
+
+	fw := &mockFirewallUpdater{}
+
+	raw := makeBpfEvent(BpfBlockedEvent{
+		IpVersion: 4,
+		Allowed:   0,
+		IpProto:   unix.IPPROTO_TCP,
+		SrcIp:     ipv4ToUint32("10.0.0.1"),
+		DstIp:     ipv4ToUint32("23.62.177.200"),
+		SrcPort:   54321,
+		DstPort:   8080, // outside the origin rule's :443 allow set
+	})
+
+	reverseDNSMu.Lock()
+	reverseDNSCache = make(map[string]time.Time)
+	reverseDNSMu.Unlock()
+
+	processEvent(raw, cm, nil, auditLogger, fw, newTestLogger())
+
+	events := readAuditEvents(t, auditPath)
+	require.Len(t, events, 1)
+	assert.Equal(t, EventConnectionBlocked, events[0].EventType,
+		":8080 is outside the origin rule's :443 allow set, so it stays blocked")
+	assert.Equal(t, "www.microsoft.com", events[0].DstHostname)
+	assert.Equal(t, chain, events[0].CNAMETarget)
+}
+
 // TestProcessEvent_LateResolvedDstPortNotInRulePortsStaysBlocked guards against
 // a subtle bug: when the IP's hostname matches an allow rule but the event's
 // dst_port is NOT in the rule's allow set, the retry will still be blocked,

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -862,7 +862,7 @@ func TestProcessEvent_CNAMEDerivedAttributesToOrigin(t *testing.T) {
 	const edge = "e13678.dscb.akamaiedge.net"
 	chain := []string{"www.microsoft.com", edge}
 	cm.UpdateDNSMapping(edge, "23.62.177.200")
-	cm.RecordCNAMEChain("23.62.177.200", chain)
+	cm.RecordCNAMEChain("23.62.177.200", chain, time.Hour)
 
 	raw := makeBpfEvent(BpfBlockedEvent{
 		IpVersion: 4,
@@ -912,7 +912,7 @@ func TestProcessEvent_CNAMEDerivedBlockedAttributesToOrigin(t *testing.T) {
 	const edge = "e13678.dscb.akamaiedge.net"
 	chain := []string{"www.microsoft.com", edge}
 	cm.UpdateDNSMapping(edge, "23.62.177.200")
-	cm.RecordCNAMEChain("23.62.177.200", chain)
+	cm.RecordCNAMEChain("23.62.177.200", chain, time.Hour)
 
 	fw := &mockFirewallUpdater{}
 

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -845,7 +845,7 @@ func TestProcessEvent_BlockedNoMatchStillLogsBlocked(t *testing.T) {
 // TestProcessEvent_CNAMEDerivedAttributesToOrigin covers the reporting fix for
 // transparent CNAME support: a connection to a CNAME target's IP (the IP maps
 // to the opaque edge name) must be reported under the origin hostname the user
-// allowed, with the full chain surfaced as the cname_target drill-down field.
+// allowed, with the full chain surfaced as the cname_chain drill-down field.
 func TestProcessEvent_CNAMEDerivedAttributesToOrigin(t *testing.T) {
 	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
 	auditLogger, err := NewAuditLogger(auditPath, false)
@@ -885,7 +885,7 @@ func TestProcessEvent_CNAMEDerivedAttributesToOrigin(t *testing.T) {
 	assert.Equal(t, EventConnectionAllowed, events[0].EventType)
 	assert.Equal(t, "www.microsoft.com", events[0].DstHostname,
 		"event must be attributed to the origin the user allowed, not the CNAME edge")
-	assert.Equal(t, chain, events[0].CNAMETarget,
+	assert.Equal(t, chain, events[0].CNAMEChain,
 		"the full CNAME chain must be surfaced as the drill-down field")
 }
 
@@ -937,7 +937,7 @@ func TestProcessEvent_CNAMEDerivedBlockedAttributesToOrigin(t *testing.T) {
 	assert.Equal(t, EventConnectionBlocked, events[0].EventType,
 		":8080 is outside the origin rule's :443 allow set, so it stays blocked")
 	assert.Equal(t, "www.microsoft.com", events[0].DstHostname)
-	assert.Equal(t, chain, events[0].CNAMETarget)
+	assert.Equal(t, chain, events[0].CNAMEChain)
 }
 
 // TestProcessEvent_LateResolvedDstPortNotInRulePortsStaysBlocked guards against

--- a/proto/v1/cargo_wall_action.proto
+++ b/proto/v1/cargo_wall_action.proto
@@ -66,6 +66,10 @@ message CargoWallActionEvent {
   optional string process = 8;
   CargoWallEventCategory category = 9;
   optional CargoWallAutoAllowedType auto_allowed_type = 10;
+  // Full CNAME chain (origin..target) when the hostname was reached via a CNAME
+  // of an allowed host; empty otherwise. The first element is the origin the
+  // user allowed, the last is the edge/target actually connected to.
+  repeated string cname_target = 11;
 }
 
 message CreateCargoWallActionJobRequest {

--- a/proto/v1/cargo_wall_action.proto
+++ b/proto/v1/cargo_wall_action.proto
@@ -69,7 +69,7 @@ message CargoWallActionEvent {
   // Full CNAME chain (origin..target) when the hostname was reached via a CNAME
   // of an allowed host; empty otherwise. The first element is the origin the
   // user allowed, the last is the edge/target actually connected to.
-  repeated string cname_target = 11;
+  repeated string cname_chain = 11;
 }
 
 message CreateCargoWallActionJobRequest {


### PR DESCRIPTION
Closes #72

## Why

Transparent CNAME support (#62/#63, #67/#68) lets cargowall allow the resolved IPs of a CNAME **target** of an allowed host — even when the chain is split across separate DNS round-trips (CDN-fronted PKI, dynamic edge labels). That closed a real enforcement gap but created a **reporting** one: when a client queries a CNAME target directly, its IP maps to that opaque edge name (e.g. `e13678.dscb.akamaiedge.net`), so connection events look like traffic to a host the user never allow-listed, with no explanation.

This PR reports those events under the **enabling rule hostname** the user actually allowed (e.g. `www.microsoft.com`) and surfaces the full CNAME chain as a drill-down, plus adds a log when CNAME targets are learned so the allow path is auditable.

## What

- **Retain origin + chain (`pkg/dns/server.go`):** `cnameAllowed`'s value goes from `[]config.Port` to `derivedAllow{ports, chain}`, carrying the full ordered chain (`origin → … → target`). The chain is built while walking `cnameChainTargets`, and transitive (split-round-trip) learning extends the parent's chain. `mergeDerivedAllow` unions ports across origins while keeping the first chain (stable attribution).
- **IP → origin attribution (`pkg/config/config.go`):** `RecordCNAMEChain` / `LookupCNAMEChain` over a per-IP, bounded, **recency-ranked set of origins** (`ipToCNAMEOrigins`), populated in the derived-enforcement loop (same place the IPs are written to BPF) and sharing the existing `ipLastSeen` / `cleanupOldEntries` eviction. A single CDN/edge IP is reachable via several allowed origins; `mergeDerivedAllow` keeps the chain last-write-wins and `LookupCNAMEChain` returns the most recently-seen origin whose chain is still live ("currently chains here"), falling back to the most recent once all have expired — i.e. the origin the **current request** most likely chased, not just the first one learned.
- **Report under the origin (`pkg/events/events.go`):** before the late-allow check, swap the reported hostname to `chain[0]` and attach the chain. Placing the swap before late-allow also makes a *blocked* derived connection on a non-inherited port attribute to the origin and evaluate against the origin's rule.
- **`cname_chain` drill-down field:** added to live logs (`"cname_chain", origin → … → target`, only when present) and to the audit JSONL (`AuditEvent.CNAMETarget`, `json:"cname_chain,omitempty"`); threaded through the four `Log*` calls.
- **Cloud summary push:** new `repeated string cname_chain = 11` on `CargoWallActionEvent` (regenerated `pb`), mapped in `auditEventToProto`. The core attribution (`DstHostname` = origin) already flows to the summary via `event.Hostname` with no proto change.
- **Learn-time logging (`pkg/dns/server.go`):** `Learned CNAME target` at Info on first-learn (Debug on refresh), recording `target`, `origin`, full `chain`, `inherited_ports`, and `source` (`rule:<pattern>` vs `derived`). Makes "was this edge ever learned, and from which origin?" answerable from the logs.

## Out of scope / follow-ups

- Rendering `cname_chain` in the cloud **Baseline Entries** table lives in the Controller service (C# `Controller.ApiService`, see the proto `csharp_namespace`) — this PR only populates the field.
- Startup pre-population needs no change: Phase-2 resolves through the proxy (so chains are learned), and Phase-1 system-cache IPs already map directly to the configured hostname.

## Attribution accuracy

For an IP shared by multiple allowed origins, attribution uses the most recently-resolved origin that still chains to it (see above), which matches the origin a chain-chasing client is currently following. Residual: connection events are processed asynchronously off the ringbuf, so "most-recent live origin at report time" can still lag connect time — this narrows the window but doesn't fully close it (closing it would need connect-time capture, impractical given the systemd-resolved DNS indirection). Ports are unioned regardless, so **enforcement is unaffected** — this only refines the display/audit attribution, and the full `cname_chain` chain is always shown so the real edge is visible either way.

## Testing

- New/updated unit tests in `pkg/dns`, `pkg/config`, `pkg/events`: chain learning + transitive extension, `mergeDerivedAllow` first-chain/union, `RecordCNAMEChain`/`LookupCNAMEChain` round-trip + copy + eviction, and `processEvent` origin attribution + `cname_chain` on both the allowed and blocked paths.
- `GOOS=linux go build ./...`, `staticcheck ./...`, and `gofumpt -l` are clean. Unit tests run on linux/CI (the dev host is darwin; the eBPF packages are `//go:build linux`).

