### PR TITLE
#77 fix cname dedupe

### DIFF
--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -264,31 +264,34 @@ type dedupKey struct {
 	eventType events.AuditEventType
 }
 
+// backfillDistinguishingFields keeps one row per destination while preserving
+// distinguishing fields carried only by a later duplicate (e.g. a CNAME chain
+// or auto-allowed type — see issue #77). Only empty fields on the retained
+// representative are filled; a value already present is authoritative.
+// MatchedRule needs no backfill: only connection_late_allowed events carry it,
+// and they always do, so with eventType in the dedup key a same-key group is
+// uniformly populated or uniformly empty.
+func backfillDistinguishingFields(rep, dup *events.AuditEvent) {
+	if len(rep.CNAMEChain) == 0 && len(dup.CNAMEChain) > 0 {
+		rep.CNAMEChain = dup.CNAMEChain
+	}
+	if rep.AutoAllowedType == "" && dup.AutoAllowedType != "" {
+		rep.AutoAllowedType = dup.AutoAllowedType
+	}
+}
+
 func deduplicateStepEvents(stepEvents []StepEvents) {
-	for i, se := range stepEvents {
+	for i := range stepEvents {
 		seen := make(map[dedupKey]int) // key -> index into deduped
 		var deduped []events.AuditEvent
-		for _, event := range se.Events {
+		for _, event := range stepEvents[i].Events {
 			dest := event.DstHostname
 			if dest == "" {
 				dest = event.DstIP
 			}
 			key := dedupKey{process: event.Process, dest: dest, port: event.DstPort, protocol: event.Protocol, eventType: event.EventType}
 			if idx, exists := seen[key]; exists {
-				// Keep one row per destination, but backfill distinguishing
-				// fields the retained representative is missing (e.g. a CNAME
-				// chain or auto-allowed type carried only by a later duplicate
-				// — see issue #77). Only fill empty fields; a value already on
-				// the representative is authoritative. MatchedRule needs no
-				// backfill: only connection_late_allowed events carry it, and
-				// they always do, so with eventType in the key a same-key group
-				// is uniformly populated or uniformly empty.
-				if len(deduped[idx].CNAMEChain) == 0 && len(event.CNAMEChain) > 0 {
-					deduped[idx].CNAMEChain = event.CNAMEChain
-				}
-				if deduped[idx].AutoAllowedType == "" && event.AutoAllowedType != "" {
-					deduped[idx].AutoAllowedType = event.AutoAllowedType
-				}
+				backfillDistinguishingFields(&deduped[idx], &event)
 				continue
 			}
 			seen[key] = len(deduped)

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -266,7 +266,7 @@ type dedupKey struct {
 
 func deduplicateStepEvents(stepEvents []StepEvents) {
 	for i, se := range stepEvents {
-		seen := make(map[dedupKey]struct{})
+		seen := make(map[dedupKey]int) // key -> index into deduped
 		var deduped []events.AuditEvent
 		for _, event := range se.Events {
 			dest := event.DstHostname
@@ -274,10 +274,25 @@ func deduplicateStepEvents(stepEvents []StepEvents) {
 				dest = event.DstIP
 			}
 			key := dedupKey{process: event.Process, dest: dest, port: event.DstPort, protocol: event.Protocol, eventType: event.EventType}
-			if _, exists := seen[key]; !exists {
-				seen[key] = struct{}{}
-				deduped = append(deduped, event)
+			if idx, exists := seen[key]; exists {
+				// Keep one row per destination, but backfill distinguishing
+				// fields the retained representative is missing (e.g. a CNAME
+				// chain or auto-allowed type carried only by a later duplicate
+				// — see issue #77). Only fill empty fields; a value already on
+				// the representative is authoritative. MatchedRule needs no
+				// backfill: only connection_late_allowed events carry it, and
+				// they always do, so with eventType in the key a same-key group
+				// is uniformly populated or uniformly empty.
+				if len(deduped[idx].CNAMEChain) == 0 && len(event.CNAMEChain) > 0 {
+					deduped[idx].CNAMEChain = event.CNAMEChain
+				}
+				if deduped[idx].AutoAllowedType == "" && event.AutoAllowedType != "" {
+					deduped[idx].AutoAllowedType = event.AutoAllowedType
+				}
+				continue
 			}
+			seen[key] = len(deduped)
+			deduped = append(deduped, event)
 		}
 		stepEvents[i].Events = deduped
 	}

--- a/cmd/summary_test.go
+++ b/cmd/summary_test.go
@@ -175,6 +175,27 @@ func TestSummary_DeduplicateStepEvents_ChainBackfilledFromLaterDuplicate(t *test
 	assert.Equal(t, ts, stepEvents[0].Events[0].Timestamp, "representative is still the first-seen event")
 }
 
+// The backfill is unconditional on EventType — the Log*Blocked paths also
+// emit chains (e.g. a derived connection blocked on a non-inherited port is
+// attributed to the origin with its chain), so a chain carried by a later
+// blocked duplicate must be preserved too.
+func TestSummary_DeduplicateStepEvents_ChainBackfilledOnBlockedEvent(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	chain := []string{"auth.docker.io", "auth.docker.io.cdn.cloudflare.net"}
+	stepEvents := []StepEvents{
+		{
+			Step: GitHubStep{Name: "build"},
+			Events: []events.AuditEvent{
+				{Timestamp: ts, EventType: events.EventConnectionBlocked, DstHostname: "auth.docker.io", DstIP: "1.1.1.1", DstPort: 25, Protocol: "TCP", Process: "curl"},
+				{Timestamp: ts.Add(time.Second), EventType: events.EventConnectionBlocked, DstHostname: "auth.docker.io", DstIP: "2.2.2.2", DstPort: 25, Protocol: "TCP", Process: "curl", CNAMEChain: chain},
+			},
+		},
+	}
+	deduplicateStepEvents(stepEvents)
+	require.Len(t, stepEvents[0].Events, 1)
+	assert.Equal(t, chain, stepEvents[0].Events[0].CNAMEChain, "chain backfilled onto a blocked representative")
+}
+
 // If the representative already carries a chain, a later chainless duplicate
 // must not clobber it.
 func TestSummary_DeduplicateStepEvents_ChainNotOverwritten(t *testing.T) {

--- a/cmd/summary_test.go
+++ b/cmd/summary_test.go
@@ -151,6 +151,74 @@ func TestSummary_DeduplicateStepEvents_DifferentProtocolsKept(t *testing.T) {
 	assert.Len(t, stepEvents[0].Events, 2, "TCP and UDP observations on the same dest:port must remain separate")
 }
 
+// A CNAME-derived connection is attributed to its origin hostname (chain[0]),
+// so a chain-bearing event and a plain direct connection to the same origin
+// share a dedup key. First-seen wins, so when the chainless direct hit sorts
+// first the chain must be backfilled onto it rather than dropped (issue #77).
+func TestSummary_DeduplicateStepEvents_ChainBackfilledFromLaterDuplicate(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	chain := []string{"auth.docker.io", "auth.docker.io.cdn.cloudflare.net"}
+	stepEvents := []StepEvents{
+		{
+			Step: GitHubStep{Name: "build"},
+			Events: []events.AuditEvent{
+				// First-seen: plain direct connection, no chain.
+				{Timestamp: ts, EventType: events.EventConnectionAllowed, DstHostname: "auth.docker.io", DstIP: "1.1.1.1", DstPort: 443, Protocol: "TCP", Process: "curl"},
+				// Later duplicate (same key): CNAME-derived, carries the chain.
+				{Timestamp: ts.Add(time.Second), EventType: events.EventConnectionAllowed, DstHostname: "auth.docker.io", DstIP: "2.2.2.2", DstPort: 443, Protocol: "TCP", Process: "curl", CNAMEChain: chain},
+			},
+		},
+	}
+	deduplicateStepEvents(stepEvents)
+	require.Len(t, stepEvents[0].Events, 1, "same origin collapses to one row")
+	assert.Equal(t, chain, stepEvents[0].Events[0].CNAMEChain, "chain backfilled from the later duplicate")
+	assert.Equal(t, ts, stepEvents[0].Events[0].Timestamp, "representative is still the first-seen event")
+}
+
+// If the representative already carries a chain, a later chainless duplicate
+// must not clobber it.
+func TestSummary_DeduplicateStepEvents_ChainNotOverwritten(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	chain := []string{"auth.docker.io", "auth.docker.io.cdn.cloudflare.net"}
+	stepEvents := []StepEvents{
+		{
+			Step: GitHubStep{Name: "build"},
+			Events: []events.AuditEvent{
+				{Timestamp: ts, EventType: events.EventConnectionAllowed, DstHostname: "auth.docker.io", DstIP: "2.2.2.2", DstPort: 443, Protocol: "TCP", Process: "curl", CNAMEChain: chain},
+				{Timestamp: ts.Add(time.Second), EventType: events.EventConnectionAllowed, DstHostname: "auth.docker.io", DstIP: "1.1.1.1", DstPort: 443, Protocol: "TCP", Process: "curl"},
+			},
+		},
+	}
+	deduplicateStepEvents(stepEvents)
+	require.Len(t, stepEvents[0].Events, 1)
+	assert.Equal(t, chain, stepEvents[0].Events[0].CNAMEChain, "retained chain must be preserved")
+}
+
+// auto_allowed_type is per-IP (CIDR pass of GetAutoAllowedType) while the
+// dedup key ignores DstIP when a hostname is set, so round-robin DNS can
+// produce same-key duplicates where only a later one carries the type — it
+// must be backfilled when the representative lacks it, but never overwritten.
+func TestSummary_DeduplicateStepEvents_AutoAllowedTypeBackfilled(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	stepEvents := []StepEvents{
+		{
+			Step: GitHubStep{Name: "build"},
+			Events: []events.AuditEvent{
+				// First-seen: resolved IP outside any auto-allowed range.
+				{Timestamp: ts, EventType: events.EventConnectionAllowed, DstHostname: "a.com", DstIP: "1.1.1.1", DstPort: 443, Protocol: "TCP", Process: "curl"},
+				// Later duplicate: resolved IP inside an auto-allowed range.
+				{Timestamp: ts.Add(time.Second), EventType: events.EventConnectionAllowed, DstHostname: "a.com", DstIP: "2.2.2.2", DstPort: 443, Protocol: "TCP", Process: "curl", AutoAllowedType: "dns"},
+				// Third duplicate: a different type must not overwrite.
+				{Timestamp: ts.Add(2 * time.Second), EventType: events.EventConnectionAllowed, DstHostname: "a.com", DstIP: "3.3.3.3", DstPort: 443, Protocol: "TCP", Process: "curl", AutoAllowedType: "github_service"},
+			},
+		},
+	}
+	deduplicateStepEvents(stepEvents)
+	require.Len(t, stepEvents[0].Events, 1)
+	assert.Equal(t, "dns", stepEvents[0].Events[0].AutoAllowedType, "missing auto_allowed_type backfilled from the first duplicate that carries one, later values don't overwrite")
+	assert.Equal(t, ts, stepEvents[0].Events[0].Timestamp, "representative is still the first-seen event")
+}
+
 // --- correlateEventsToSteps ---
 
 func TestSummary_CorrelateEventsToSteps_EventInStep(t *testing.T) {


### PR DESCRIPTION
Closes #77

## Why

`cargowall summary` dedupes connection events per step before the SaaS push, on a key of `(process, dest, port, protocol, eventType)` — and keeps the **first-seen** event wholesale. Transparent CNAME support (#63/#68/#73) attributes a CNAME-derived connection to its **origin hostname** (`chain[0]`), the same `dest` a direct connection to that origin reports. So a chain-bearing event and a chainless direct hit to the same origin collide on the dedup key, and whenever the chainless one sorts first, the chain-bearing event is discarded — the pushed/stored event has an empty `cname_chain` even though the firewall logged the chain correctly (see #77 for the observed `auth.docker.io` evidence). The same wholesale discard applies to `auto_allowed_type`, which is per-IP (CIDR pass of `GetAutoAllowedType`) while the dedup key ignores `DstIP` when a hostname is set — round-robin DNS can produce same-key duplicates where only a later one carries the type.

## What

- **`cmd/summary.go` — `deduplicateStepEvents`:** the `seen` map now stores the index of the retained representative (`map[dedupKey]int`). On a collision, instead of discarding the duplicate outright, backfill the distinguishing fields the representative is missing:
  - `CNAMEChain` — filled when the representative has none and the duplicate carries one;
  - `AutoAllowedType` — same fill-if-empty rule.

  Fill-if-empty only: the first-seen event stays the representative and an existing value is never overwritten. One row per destination is preserved (the merge approach preferred in #77, not the add-chain-to-key alternative, which would emit a redundant chainless row). No signature or caller changes — `auditEventToProto` picks up the now-populated fields via its existing non-empty guards.

  `MatchedRule` deliberately gets **no** backfill: only `connection_late_allowed` events carry it, and they always do (`HasAllow()` ⇒ non-empty rule), so with `eventType` in the dedup key a same-key group is uniformly populated or uniformly empty — the backfill branch could never fire. Documented in a comment.

- **`cmd/summary_test.go`:** three new tests alongside the existing dedup group —
  - `ChainBackfilledFromLaterDuplicate` — the #77 repro shape: chainless direct hit first, chain-bearing CNAME-derived duplicate second → one row, chain preserved, first-seen timestamp retained;
  - `ChainNotOverwritten` — a later chainless duplicate doesn't clobber an existing chain;
  - `AutoAllowedTypeBackfilled` — per-IP round-robin shape: type backfilled from the first duplicate that carries one, a later different type doesn't overwrite.

## Semantics note

For a merged row with mixed auto/non-auto duplicates, the auto-allow attribution now deterministically wins (previously the label was ordering-arbitrary, first-seen verbatim). This means `totalAutoAllowed` / `AutoAllowedConnections` count a destination as auto-allowed if **any** connection to it was — intended, since at least one connection genuinely took the auto-allow path, and the alternative silently hides that attribution.

## Testing

- All 10 `TestSummary_DeduplicateStepEvents_*` tests (7 existing + 3 new) and the full `cmd` package pass on linux (`golang:1.25` container; the dev host is darwin and these files are `//go:build linux`).
- `GOOS=linux go build ./...`, `go vet`, `staticcheck`, and `gofumpt -l` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
