### PR TITLE
CodeCargo: update code-cargo/cargowall-action to v1.3.3

### DIFF
--- a/.github/workflows/bpf-generate.yml
+++ b/.github/workflows/bpf-generate.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+      - uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+      - uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -56,7 +56,7 @@ jobs:
       id-token: write
       checks: write
     steps:
-      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+      - uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -95,7 +95,7 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+      - uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -141,7 +141,7 @@ jobs:
         run: chmod +x bin/cargowall
 
       - name: Start CargoWall via Action
-        uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+        uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
         with:
           mode: enforce
           offline: 'true'
@@ -288,7 +288,7 @@ jobs:
         run: chmod +x bin/cargowall
 
       - name: Start CargoWall via Action
-        uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+        uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
         with:
           mode: audit
           offline: 'true'
@@ -875,6 +875,6 @@ jobs:
       - name: Make binary executable
         run: chmod +x bin/cargowall
 
-      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+      - uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
         with:
           binary-path: ./bin/cargowall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     steps:
-      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+      - uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -70,7 +70,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: code-cargo/cargowall-action@41060a3cd1b22ea4922be4a8769c149983ef4eae # v1.3.0
+      - uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
 
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Update code-cargo/cargowall-action

Updates all references to `code-cargo/cargowall-action` to version `v1.3.3`.

> SHA-pinned to `aa88f652e49b36a660add09311d077383dbc2ae7` (v1.3.3)

### Modified workflows
- `.github/workflows/bpf-generate.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

---
Generated by [CodeCargo](https://codecargo.com)