### PR TITLE
#87 derive CNAME-allow TTL from chain running max and floor small TTLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 VERSION ?= develop
 GOARCH ?= $(shell go env GOARCH)
 
-# Common directories
-bin_dir := bin
-
-# Common build flags
-LDFLAGS := -w -s -X main.Version=$(VERSION)
-
 ifdef CI_VERSION
 VERSION := $(CI_VERSION)
 endif
+
+# Common directories
+bin_dir := bin
+
+# Common build flags. LDFLAGS uses immediate expansion, so the CI_VERSION
+# override must come before it, and the -X target must match the (unexported)
+# `version` var in cargowall.go.
+LDFLAGS := -w -s -X main.version=$(VERSION)
 
 # Define color codes
 GREEN := \033[32m

--- a/pkg/dns/lru.go
+++ b/pkg/dns/lru.go
@@ -49,13 +49,20 @@ func newLRUCache[K comparable, V any](capacity int) *lruCache[K, V] {
 // Get returns the value for key and moves it to the front of the LRU list.
 // Returns false if the key is missing or expired.
 func (c *lruCache[K, V]) Get(key K) (V, bool) {
+	v, _, ok := c.GetWithExpiry(key)
+	return v, ok
+}
+
+// GetWithExpiry is Get plus the entry's expiry time (zero = never expires),
+// for callers that need the remaining lifetime as well as the value.
+func (c *lruCache[K, V]) GetWithExpiry(key K) (V, time.Time, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	elem, ok := c.items[key]
 	if !ok {
 		var zero V
-		return zero, false
+		return zero, time.Time{}, false
 	}
 
 	e := elem.Value.(*lruEntry[K, V])
@@ -65,11 +72,11 @@ func (c *lruCache[K, V]) Get(key K) (V, bool) {
 		c.order.Remove(elem)
 		delete(c.items, key)
 		var zero V
-		return zero, false
+		return zero, time.Time{}, false
 	}
 
 	c.order.MoveToFront(elem)
-	return e.value, true
+	return e.value, e.expiry, true
 }
 
 // Put adds or updates a key-value pair. If ttl is 0, the entry never expires.
@@ -109,10 +116,15 @@ func (c *lruCache[K, V]) Put(key K, value V, ttl time.Duration) {
 }
 
 // Merge stores compose(existing, value) under key — or value alone when the
-// key is absent or already expired — refreshing the TTL and moving the entry
-// to the front. compose runs while the cache lock is held, so concurrent Merge
-// calls on the same key accumulate without the lost-update race a separate
-// Get-then-Put would have. If ttl is 0 the entry never expires.
+// key is absent or already expired — and moves the entry to the front.
+// compose runs while the cache lock is held, so concurrent Merge calls on the
+// same key accumulate without the lost-update race a separate Get-then-Put
+// would have. If ttl is 0 the entry never expires.
+//
+// Expiry is extend-only for a live entry: the later of the existing and
+// incoming expiry wins (never-expires wins over any finite expiry), so a
+// re-merge with a shorter TTL refreshes the value but cannot truncate a
+// longer lifetime an earlier merge established.
 //
 // Returns whether a live existing entry was composed with (true) versus a fresh
 // insert — i.e. an absent key or one treated as absent because it had expired.
@@ -134,6 +146,13 @@ func (c *lruCache[K, V]) Merge(key K, value V, ttl time.Duration, compose func(e
 		live := e.expiry.IsZero() || time.Now().Before(e.expiry)
 		if live {
 			value = compose(e.value, value)
+			// Extend-only expiry (see doc comment): keep the later of
+			// existing and incoming; zero (never expires) wins either way.
+			if expiry.IsZero() || e.expiry.IsZero() {
+				expiry = time.Time{}
+			} else if e.expiry.After(expiry) {
+				expiry = e.expiry
+			}
 		}
 		c.order.MoveToFront(elem)
 		e.value = value

--- a/pkg/dns/lru_test.go
+++ b/pkg/dns/lru_test.go
@@ -215,6 +215,38 @@ func TestLRUCache_MergeReportsLiveness(t *testing.T) {
 	assert.Equal(t, 7, got, "expired Merge replaces (not composes) → 7")
 }
 
+// Merge's expiry is extend-only for a live entry: a re-merge with a shorter
+// TTL still composes the value but keeps the later expiry, a longer TTL
+// extends it, and never-expires (ttl 0) wins over any finite expiry. Guards
+// the #87 running-max fix: a partial-chain re-learn with a smaller max must
+// not truncate a lifetime an earlier response established.
+func TestLRUCache_MergeExpiryExtendOnly(t *testing.T) {
+	c := newLRUCache[string, int](10)
+	sum := func(existing, incoming int) int { return existing + incoming }
+
+	c.Merge("k", 1, 100*time.Second, sum)
+	assert.True(t, c.Merge("k", 2, 10*time.Second, sum), "shorter re-merge still composes with the live entry")
+	exp, ok := c.peekExpiry("k")
+	require.True(t, ok)
+	assert.Greater(t, time.Until(exp), 90*time.Second, "shorter re-merge must not truncate the existing expiry")
+	got, _ := c.Get("k")
+	assert.Equal(t, 3, got, "value still composes on a shorter re-merge")
+
+	c.Merge("k", 4, 200*time.Second, sum)
+	exp, ok = c.peekExpiry("k")
+	require.True(t, ok)
+	assert.Greater(t, time.Until(exp), 190*time.Second, "longer re-merge extends the expiry")
+
+	c.Merge("k", 8, 0, sum)
+	exp, ok = c.peekExpiry("k")
+	require.True(t, ok)
+	assert.True(t, exp.IsZero(), "never-expires re-merge wins over a finite expiry")
+	assert.True(t, c.Merge("k", 16, time.Minute, sum), "finite re-merge of a never-expiring entry composes")
+	exp, ok = c.peekExpiry("k")
+	require.True(t, ok)
+	assert.True(t, exp.IsZero(), "existing never-expires wins over an incoming finite expiry")
+}
+
 // Concurrent Get/Put must not race. Run under `go test -race` to catch any
 // missed locking.
 func TestLRUCache_ConcurrentAccess(t *testing.T) {

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -516,11 +516,19 @@ func (s *Server) enforceDNSResponse(canonicalHostname string, resp *dns.Msg, dep
 	// (a misbehaving or spoofed authoritative server for an allowed domain)
 	// are ignored instead of registering arbitrary names; depth is bounded
 	// by the 10k LRU and per-hop TTL. Targets inherit the origin's allow
-	// ports. Each target is learned for its own CNAME TTL (not the response-
-	// wide min, which would shorten it to the final address record's TTL),
-	// floored by derivedCNAMETTL. A target whose entry expires before its
-	// origin's dnsCache entry just gets re-REFUSED until the next origin
-	// query re-learns it — self-healing and TTL-bounded.
+	// ports. Each target is learned for the running max of the CNAME TTLs
+	// from the origin down to it (not the response-wide min, which would
+	// shorten it to the final address record's TTL, and not the hop's own
+	// TTL alone): a client reaches a hop by following its ancestors' cached
+	// records, so it can keep querying that hop directly for as long as the
+	// longest-lived record above it survives — a short-TTL tail under a
+	// long-TTL ancestor (the common CDN shape, #87) would otherwise expire
+	// into REFUSED while cache still points clients at it, with no origin
+	// re-query to re-learn it. The max is floored by derivedCNAMETTL and
+	// keeps the entry strictly bounded by the chain's own record TTLs. A
+	// target whose entry still expires before the client's interest in it
+	// just gets re-REFUSED until the next origin query re-learns it —
+	// self-healing and TTL-bounded.
 	//
 	// Not gated on s.filterQueries: the enforcement use applies even when
 	// query filtering is off; isQueryAllowed still only consults the cache
@@ -553,8 +561,15 @@ func (s *Server) enforceDNSResponse(canonicalHostname string, resp *dns.Msg, dep
 			path = []string{canonicalHostname}
 			source = "rule:" + verdict.AllowRule
 		}
+		// reach is the running max TTL from the chain root down to the
+		// current hop — how long a chain-chasing client can still be
+		// pointed at it (see the comment above).
+		var reach uint32
 		for _, link := range links {
-			ttl := time.Duration(derivedCNAMETTL(link.ttl)) * time.Second
+			if link.ttl > reach {
+				reach = link.ttl
+			}
+			ttl := time.Duration(derivedCNAMETTL(reach)) * time.Second
 			path = append(path, link.target)
 			chain := append([]string{}, path...)
 			// Log a first-learn (or re-learn after expiry) at Info so a
@@ -805,15 +820,23 @@ func cnameChainTargets(qname string, answers []dns.RR) []cnameLink {
 	return chain
 }
 
-// derivedCNAMETTL floors a CNAME record's TTL for the derived CNAME-allow
+// derivedCNAMETTL floors a CNAME chain TTL for the derived CNAME-allow
 // cache. A record's TTL can be 0 (some CDNs/load-balancers return TTL 0 to
 // defeat caching), and lruCache treats a 0 duration as "never expires", so a
 // literal 0 would pin the derived allow indefinitely — the opposite of the
 // TTL-bounded guarantee. Floor it to the same default the dnsCache path uses
-// (300s / 5 min).
+// (300s / 5 min). Small nonzero TTLs are floored too (#87): a TTL-1 chain
+// would otherwise yield a 1-second allow window — strictly worse than the
+// TTL-0 case this guards — and REFUSE the client's very next direct query
+// for the target.
+const minDerivedCNAMETTL = 30 // seconds
+
 func derivedCNAMETTL(ttl uint32) uint32 {
 	if ttl == 0 {
 		return 300
+	}
+	if ttl < minDerivedCNAMETTL {
+		return minDerivedCNAMETTL
 	}
 	return ttl
 }

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -420,7 +420,7 @@ func (s *Server) handleDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// Cache successful responses
 		if resp.Rcode == dns.RcodeSuccess && len(resp.Answer) > 0 {
 			// Find minimum TTL from answers
-			minTTL := uint32(300) // Default 5 minutes
+			minTTL := uint32(defaultDNSTTL)
 			for _, answer := range resp.Answer {
 				if answer.Header().Ttl > 0 && answer.Header().Ttl < minTTL {
 					minTTL = answer.Header().Ttl
@@ -488,10 +488,21 @@ func (s *Server) enforceDNSResponse(canonicalHostname string, resp *dns.Msg, dep
 	// Any matching rule is authoritative.
 	var derivedPorts []config.Port
 	var derivedChain []string
+	// derivedReach seeds the chain's running-max TTL (see the learning loop
+	// below) with the parent entry's remaining life, so a chain split across
+	// query round-trips keeps the ancestor guarantee: a short-TTL tail
+	// learned from this response must outlive its own record for as long as
+	// the already-learned ancestor's records can still point clients at it.
+	var derivedReach uint32
 	derived := false
 	if !verdict.Matched() && s.cnameAllowed != nil {
-		if entry, ok := s.cnameAllowed.Get(canonicalHostname); ok {
+		if entry, exp, ok := s.cnameAllowed.GetWithExpiry(canonicalHostname); ok {
 			derived, derivedPorts, derivedChain = true, entry.ports, entry.chain
+			if rem := time.Until(exp); exp.IsZero() || rem > maxDerivedCNAMETTL*time.Second {
+				derivedReach = maxDerivedCNAMETTL
+			} else if rem > 0 {
+				derivedReach = uint32(rem / time.Second)
+			}
 		}
 	}
 
@@ -515,20 +526,26 @@ func (s *Server) enforceDNSResponse(canonicalHostname string, resp *dns.Msg, dep
 	// follows the chain from the query name only, so unrelated CNAME records
 	// (a misbehaving or spoofed authoritative server for an allowed domain)
 	// are ignored instead of registering arbitrary names; depth is bounded
-	// by the 10k LRU and per-hop TTL. Targets inherit the origin's allow
-	// ports. Each target is learned for the running max of the CNAME TTLs
-	// from the origin down to it (not the response-wide min, which would
-	// shorten it to the final address record's TTL, and not the hop's own
-	// TTL alone): a client reaches a hop by following its ancestors' cached
-	// records, so it can keep querying that hop directly for as long as the
-	// longest-lived record above it survives — a short-TTL tail under a
-	// long-TTL ancestor (the common CDN shape, #87) would otherwise expire
-	// into REFUSED while cache still points clients at it, with no origin
-	// re-query to re-learn it. The max is floored by derivedCNAMETTL and
-	// keeps the entry strictly bounded by the chain's own record TTLs. A
-	// target whose entry still expires before the client's interest in it
-	// just gets re-REFUSED until the next origin query re-learns it —
-	// self-healing and TTL-bounded.
+	// by the 10k LRU and the capped chain TTL below. Targets inherit the
+	// origin's allow ports. Each target is learned for the running max of
+	// the effective (derivedCNAMETTL-floored) CNAME TTLs from the origin
+	// down to it (not the response-wide min, which would shorten it to the
+	// final address record's TTL, and not the hop's own TTL alone): a
+	// client reaches a hop by following its ancestors' cached records, so
+	// it can keep querying that hop directly for as long as the longest-
+	// lived record above it survives — a short-TTL tail under a long-TTL
+	// ancestor (the common CDN shape, #87) would otherwise expire into
+	// REFUSED while cache still points clients at it, with no origin
+	// re-query to re-learn it. The max runs over effective TTLs so the
+	// TTL-0→defaultDNSTTL accommodation reaches descendants too, is seeded
+	// with the parent entry's remaining life when a chain splits across
+	// query round-trips (derivedReach above), and is capped at
+	// maxDerivedCNAMETTL so one huge ancestor TTL can't pin a whole chain
+	// near-indefinitely. Merge's expiry is extend-only, so a later partial-
+	// chain re-learn with a smaller max can't truncate a longer lifetime an
+	// earlier response established. A target whose entry still expires
+	// before the client's interest in it just gets re-REFUSED until the
+	// next origin query re-learns it — self-healing and TTL-bounded.
 	//
 	// Not gated on s.filterQueries: the enforcement use applies even when
 	// query filtering is off; isQueryAllowed still only consults the cache
@@ -561,15 +578,13 @@ func (s *Server) enforceDNSResponse(canonicalHostname string, resp *dns.Msg, dep
 			path = []string{canonicalHostname}
 			source = "rule:" + verdict.AllowRule
 		}
-		// reach is the running max TTL from the chain root down to the
-		// current hop — how long a chain-chasing client can still be
-		// pointed at it (see the comment above).
-		var reach uint32
+		// reach is the running max of effective TTLs from the chain root
+		// down to the current hop — how long a chain-chasing client can
+		// still be pointed at it (see the comment above).
+		reach := derivedReach
 		for _, link := range links {
-			if link.ttl > reach {
-				reach = link.ttl
-			}
-			ttl := time.Duration(derivedCNAMETTL(reach)) * time.Second
+			reach = min(max(reach, derivedCNAMETTL(link.ttl)), maxDerivedCNAMETTL)
+			ttl := time.Duration(reach) * time.Second
 			path = append(path, link.target)
 			chain := append([]string{}, path...)
 			// Log a first-learn (or re-learn after expiry) at Info so a
@@ -774,8 +789,8 @@ func mergeDerivedAllow(existing, incoming derivedAllow) derivedAllow {
 // as queryable. A visited set — seeded with qname — bounds malicious loops,
 // including ones that point back at the query name itself (N→X→N), so a crafted
 // response can't re-register qname and refresh its derived-allow TTL. Each
-// target carries its own CNAME record's TTL so the caller can expire it on the
-// hop's lifetime rather than the response-wide minimum.
+// target carries its own CNAME record's TTL; the caller folds these into the
+// chain's running-max expiry rather than using the response-wide minimum.
 func cnameChainTargets(qname string, answers []dns.RR) []cnameLink {
 	// Index CNAMEs by lowercased owner; first record for an owner wins so a
 	// duplicate owner can't redirect the walk. Allocated lazily so the common
@@ -820,25 +835,35 @@ func cnameChainTargets(qname string, answers []dns.RR) []cnameLink {
 	return chain
 }
 
-// derivedCNAMETTL floors a CNAME chain TTL for the derived CNAME-allow
-// cache. A record's TTL can be 0 (some CDNs/load-balancers return TTL 0 to
-// defeat caching), and lruCache treats a 0 duration as "never expires", so a
-// literal 0 would pin the derived allow indefinitely — the opposite of the
-// TTL-bounded guarantee. Floor it to the same default the dnsCache path uses
-// (300s / 5 min). Small nonzero TTLs are floored too (#87): a TTL-1 chain
-// would otherwise yield a 1-second allow window — strictly worse than the
-// TTL-0 case this guards — and REFUSE the client's very next direct query
-// for the target.
-const minDerivedCNAMETTL = 30 // seconds
+const (
+	// defaultDNSTTL (seconds) is the shared fallback TTL: the dnsCache
+	// response path uses it when no answer carries a usable TTL, and
+	// derivedCNAMETTL maps TTL-0 records to it — some CDNs/load-balancers
+	// return TTL 0 to defeat caching, and lruCache treats a 0 duration as
+	// "never expires", so a literal 0 would pin a derived allow
+	// indefinitely, the opposite of the TTL-bounded guarantee.
+	defaultDNSTTL = 300
+	// minDerivedCNAMETTL (seconds) floors small nonzero CNAME TTLs (#87):
+	// a TTL-1 record would otherwise yield a 1-second allow window —
+	// strictly worse than the TTL-0 case above — and REFUSE the client's
+	// very next direct query for the target.
+	minDerivedCNAMETTL = 30
+	// maxDerivedCNAMETTL (seconds) caps the chain running-max TTL so one
+	// huge (or crafted) ancestor TTL can't pin every downstream hop's
+	// derived allow near-indefinitely; matches the dnsCache no-answer
+	// default (see extractIPsFromResponse).
+	maxDerivedCNAMETTL = 86400
+)
 
+// derivedCNAMETTL returns the effective TTL (seconds) of one CNAME hop for
+// the derived CNAME-allow cache: TTL 0 maps to defaultDNSTTL and small TTLs
+// are floored to minDerivedCNAMETTL. Applied per hop BEFORE the running max
+// in the learning loop, so both floors propagate to descendant hops.
 func derivedCNAMETTL(ttl uint32) uint32 {
 	if ttl == 0 {
-		return 300
+		return defaultDNSTTL
 	}
-	if ttl < minDerivedCNAMETTL {
-		return minDerivedCNAMETTL
-	}
-	return ttl
+	return max(ttl, minDerivedCNAMETTL)
 }
 
 // extractIPsFromResponse extracts IPv4 and IPv6 addresses from msg.Answer

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1878,11 +1878,15 @@ func TestHandleDNSQuery_CNAMELearnedInAuditMode(t *testing.T) {
 }
 
 // derivedCNAMETTL floors a 0 TTL so the derived allow can never be stored as
-// a never-expiring lruCache entry; non-zero TTLs pass through unchanged.
+// a never-expiring lruCache entry, and floors small nonzero TTLs (#87) so a
+// TTL-1 chain can't yield a 1-second allow window; larger TTLs pass through
+// unchanged.
 func TestDerivedCNAMETTL(t *testing.T) {
 	assert.Equal(t, uint32(300), derivedCNAMETTL(0), "TTL 0 must be floored, not stored as never-expires")
-	assert.Equal(t, uint32(1), derivedCNAMETTL(1))
-	assert.Equal(t, uint32(20), derivedCNAMETTL(20))
+	assert.Equal(t, uint32(30), derivedCNAMETTL(1), "sub-floor TTLs must be raised to the minimum")
+	assert.Equal(t, uint32(30), derivedCNAMETTL(29), "sub-floor TTLs must be raised to the minimum")
+	assert.Equal(t, uint32(30), derivedCNAMETTL(30))
+	assert.Equal(t, uint32(45), derivedCNAMETTL(45))
 	assert.Equal(t, uint32(86400), derivedCNAMETTL(86400))
 }
 
@@ -1928,20 +1932,14 @@ func TestHandleDNSQuery_CNAMEZeroTTLStillLearns(t *testing.T) {
 	assert.LessOrEqual(t, remaining, 300*time.Second)
 }
 
-// Each CNAME target must be learned for its OWN hop's TTL, not the response-wide
-// minimum (which would fold in the final address record's shorter TTL). This
-// asserts the end-to-end wiring: handleDNSQuery → cnameChainTargets per-hop ttl
-// → derivedCNAMETTL → cnameAllowed.Put.
-func TestHandleDNSQuery_CNAMEPerHopTTLApplied(t *testing.T) {
-	cfg := config.NewConfigManager()
-	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
-		{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
-	}, config.ActionDeny))
-
-	mockFw := firewall.NewMockFirewall(t)
-	server := newTestServer(t, cfg, mockFw)
-	server.filterQueries = true
-
+// Each CNAME target must be learned for the running MAX of the chain TTLs from
+// the origin down to it (#87) — not the response-wide minimum (which would fold
+// in the final address record's shorter TTL), and not the hop's own TTL alone
+// (a short-TTL tail under a long-TTL ancestor would expire into REFUSED while
+// resolver caches still point clients at it). This asserts the end-to-end
+// wiring: handleDNSQuery → cnameChainTargets per-hop ttl → running max →
+// derivedCNAMETTL → cnameAllowed.Merge.
+func TestHandleDNSQuery_CNAMEChainTTLRunningMax(t *testing.T) {
 	const origin = "builds.dotnet.microsoft.com."
 	cn := func(owner, target string, ttl uint32) *dns.CNAME {
 		return &dns.CNAME{
@@ -1949,46 +1947,88 @@ func TestHandleDNSQuery_CNAMEPerHopTTLApplied(t *testing.T) {
 			Target: dns.Fqdn(target),
 		}
 	}
-	// origin --(120s)--> hop1 --(45s)--> a441, with a short-TTL A record (10s).
-	// If the learn path used the response-wide min, both targets would expire
-	// in ~10s; per-hop TTLs keep them at 120s and 45s.
-	resp := &dns.Msg{
-		MsgHdr:   dns.MsgHdr{Id: 7000, Response: true, Rcode: dns.RcodeSuccess},
-		Question: []dns.Question{{Name: origin, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
-		Answer: []dns.RR{
-			cn(origin, "hop1.example.net", 120),
-			cn("hop1.example.net", "a441.dscd.akamai.net", 45),
-			&dns.A{
-				Hdr: dns.RR_Header{Name: "a441.dscd.akamai.net.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 10},
-				A:   net.ParseIP("23.56.109.139"),
-			},
-		},
-	}
-	seedCachedResponse(server, origin, resp)
-
-	mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil).Once()
-
-	query := new(dns.Msg)
-	query.SetQuestion(origin, dns.TypeA)
-	query.Id = 7001
-	w := &MockResponseWriter{}
-	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
-	server.handleDNSQuery(w, query)
-	w.AssertExpectations(t)
-
-	for _, tc := range []struct {
+	type expiry struct {
 		name   string
 		ttl    time.Duration
 		lowest time.Duration
+	}
+	for _, tt := range []struct {
+		name    string
+		queryID uint16
+		hops    []dns.RR
+		want    []expiry
 	}{
-		{"hop1.example.net", 120 * time.Second, 110 * time.Second},
-		{"a441.dscd.akamai.net", 45 * time.Second, 40 * time.Second},
+		{
+			// The #87 shape: a short-TTL tail under a long-TTL ancestor. The
+			// tail inherits the ancestor's 120s — its own 45s would let it
+			// expire while a resolver still holds the 120s upper record and
+			// keeps sending clients straight to the tail. The 10s A record
+			// must not drag either down (response-wide-min regression).
+			name:    "descending TTLs: tail inherits ancestor max",
+			queryID: 7001,
+			hops: []dns.RR{
+				cn(origin, "hop1.example.net", 120),
+				cn("hop1.example.net", "a441.dscd.akamai.net", 45),
+			},
+			want: []expiry{
+				{"hop1.example.net", 120 * time.Second, 110 * time.Second},
+				{"a441.dscd.akamai.net", 120 * time.Second, 110 * time.Second},
+			},
+		},
+		{
+			// Ascending TTLs: the max only ever widens, so a hop whose own
+			// TTL exceeds every ancestor's keeps it, and the earlier hop is
+			// unaffected by the later, longer one.
+			name:    "ascending TTLs: own TTL wins when larger",
+			queryID: 7003,
+			hops: []dns.RR{
+				cn(origin, "hop1.example.net", 45),
+				cn("hop1.example.net", "a441.dscd.akamai.net", 120),
+			},
+			want: []expiry{
+				{"hop1.example.net", 45 * time.Second, 40 * time.Second},
+				{"a441.dscd.akamai.net", 120 * time.Second, 110 * time.Second},
+			},
+		},
 	} {
-		exp, ok := server.cnameAllowed.peekExpiry(tc.name)
-		require.True(t, ok, "%s should be learned", tc.name)
-		remaining := time.Until(exp)
-		assert.Greater(t, remaining, tc.lowest, "%s expiry should reflect its own CNAME TTL, not the response min", tc.name)
-		assert.LessOrEqual(t, remaining, tc.ttl, "%s expiry should not exceed its own CNAME TTL", tc.name)
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfigManager()
+			require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+				{Type: config.RuleTypeHostname, Value: "builds.dotnet.microsoft.com", Action: config.ActionAllow},
+			}, config.ActionDeny))
+
+			mockFw := firewall.NewMockFirewall(t)
+			server := newTestServer(t, cfg, mockFw)
+			server.filterQueries = true
+
+			resp := &dns.Msg{
+				MsgHdr:   dns.MsgHdr{Id: tt.queryID - 1, Response: true, Rcode: dns.RcodeSuccess},
+				Question: []dns.Question{{Name: origin, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+				Answer: append(append([]dns.RR{}, tt.hops...), &dns.A{
+					Hdr: dns.RR_Header{Name: "a441.dscd.akamai.net.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 10},
+					A:   net.ParseIP("23.56.109.139"),
+				}),
+			}
+			seedCachedResponse(server, origin, resp)
+
+			mockFw.On("AddIP", net.ParseIP("23.56.109.139"), config.ActionAllow, []config.Port(nil)).Return(true, nil).Once()
+
+			query := new(dns.Msg)
+			query.SetQuestion(origin, dns.TypeA)
+			query.Id = tt.queryID
+			w := &MockResponseWriter{}
+			w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+			server.handleDNSQuery(w, query)
+			w.AssertExpectations(t)
+
+			for _, tc := range tt.want {
+				exp, ok := server.cnameAllowed.peekExpiry(tc.name)
+				require.True(t, ok, "%s should be learned", tc.name)
+				remaining := time.Until(exp)
+				assert.Greater(t, remaining, tc.lowest, "%s expiry should reflect the chain's running-max TTL", tc.name)
+				assert.LessOrEqual(t, remaining, tc.ttl, "%s expiry should not exceed the chain's running-max TTL", tc.name)
+			}
+		})
 	}
 }
 

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1937,8 +1937,8 @@ func TestHandleDNSQuery_CNAMEZeroTTLStillLearns(t *testing.T) {
 // in the final address record's shorter TTL), and not the hop's own TTL alone
 // (a short-TTL tail under a long-TTL ancestor would expire into REFUSED while
 // resolver caches still point clients at it). This asserts the end-to-end
-// wiring: handleDNSQuery → cnameChainTargets per-hop ttl → running max →
-// derivedCNAMETTL → cnameAllowed.Merge.
+// wiring: handleDNSQuery → cnameChainTargets per-hop ttl → derivedCNAMETTL →
+// running max → cnameAllowed.Merge.
 func TestHandleDNSQuery_CNAMEChainTTLRunningMax(t *testing.T) {
 	const origin = "builds.dotnet.microsoft.com."
 	cn := func(owner, target string, ttl uint32) *dns.CNAME {
@@ -1948,15 +1948,13 @@ func TestHandleDNSQuery_CNAMEChainTTLRunningMax(t *testing.T) {
 		}
 	}
 	type expiry struct {
-		name   string
-		ttl    time.Duration
-		lowest time.Duration
+		name string
+		ttl  time.Duration
 	}
 	for _, tt := range []struct {
-		name    string
-		queryID uint16
-		hops    []dns.RR
-		want    []expiry
+		name string
+		hops []dns.RR
+		want []expiry
 	}{
 		{
 			// The #87 shape: a short-TTL tail under a long-TTL ancestor. The
@@ -1964,30 +1962,44 @@ func TestHandleDNSQuery_CNAMEChainTTLRunningMax(t *testing.T) {
 			// expire while a resolver still holds the 120s upper record and
 			// keeps sending clients straight to the tail. The 10s A record
 			// must not drag either down (response-wide-min regression).
-			name:    "descending TTLs: tail inherits ancestor max",
-			queryID: 7001,
+			name: "descending TTLs: tail inherits ancestor max",
 			hops: []dns.RR{
 				cn(origin, "hop1.example.net", 120),
 				cn("hop1.example.net", "a441.dscd.akamai.net", 45),
 			},
 			want: []expiry{
-				{"hop1.example.net", 120 * time.Second, 110 * time.Second},
-				{"a441.dscd.akamai.net", 120 * time.Second, 110 * time.Second},
+				{"hop1.example.net", 120 * time.Second},
+				{"a441.dscd.akamai.net", 120 * time.Second},
 			},
 		},
 		{
 			// Ascending TTLs: the max only ever widens, so a hop whose own
 			// TTL exceeds every ancestor's keeps it, and the earlier hop is
 			// unaffected by the later, longer one.
-			name:    "ascending TTLs: own TTL wins when larger",
-			queryID: 7003,
+			name: "ascending TTLs: own TTL wins when larger",
 			hops: []dns.RR{
 				cn(origin, "hop1.example.net", 45),
 				cn("hop1.example.net", "a441.dscd.akamai.net", 120),
 			},
 			want: []expiry{
-				{"hop1.example.net", 45 * time.Second, 40 * time.Second},
-				{"a441.dscd.akamai.net", 120 * time.Second, 110 * time.Second},
+				{"hop1.example.net", 45 * time.Second},
+				{"a441.dscd.akamai.net", 120 * time.Second},
+			},
+		},
+		{
+			// The max runs over EFFECTIVE (floored) TTLs: a sub-30s hop is
+			// raised to minDerivedCNAMETTL and a TTL-0 hop to defaultDNSTTL,
+			// and both floors reach descendants — a TTL-0 hop under a
+			// nonzero ancestor must keep the 300s defeat-caching window, not
+			// shrink to the ancestor's TTL.
+			name: "zero and sub-floor TTLs floored per hop before the max",
+			hops: []dns.RR{
+				cn(origin, "hop1.example.net", 5),
+				cn("hop1.example.net", "a441.dscd.akamai.net", 0),
+			},
+			want: []expiry{
+				{"hop1.example.net", 30 * time.Second},
+				{"a441.dscd.akamai.net", 300 * time.Second},
 			},
 		},
 	} {
@@ -2002,7 +2014,7 @@ func TestHandleDNSQuery_CNAMEChainTTLRunningMax(t *testing.T) {
 			server.filterQueries = true
 
 			resp := &dns.Msg{
-				MsgHdr:   dns.MsgHdr{Id: tt.queryID - 1, Response: true, Rcode: dns.RcodeSuccess},
+				MsgHdr:   dns.MsgHdr{Id: 7000, Response: true, Rcode: dns.RcodeSuccess},
 				Question: []dns.Question{{Name: origin, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
 				Answer: append(append([]dns.RR{}, tt.hops...), &dns.A{
 					Hdr: dns.RR_Header{Name: "a441.dscd.akamai.net.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 10},
@@ -2015,7 +2027,7 @@ func TestHandleDNSQuery_CNAMEChainTTLRunningMax(t *testing.T) {
 
 			query := new(dns.Msg)
 			query.SetQuestion(origin, dns.TypeA)
-			query.Id = tt.queryID
+			query.Id = 7001
 			w := &MockResponseWriter{}
 			w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
 			server.handleDNSQuery(w, query)
@@ -2025,11 +2037,66 @@ func TestHandleDNSQuery_CNAMEChainTTLRunningMax(t *testing.T) {
 				exp, ok := server.cnameAllowed.peekExpiry(tc.name)
 				require.True(t, ok, "%s should be learned", tc.name)
 				remaining := time.Until(exp)
-				assert.Greater(t, remaining, tc.lowest, "%s expiry should reflect the chain's running-max TTL", tc.name)
+				assert.Greater(t, remaining, tc.ttl-10*time.Second, "%s expiry should reflect the chain's running-max TTL", tc.name)
 				assert.LessOrEqual(t, remaining, tc.ttl, "%s expiry should not exceed the chain's running-max TTL", tc.name)
 			}
 		})
 	}
+}
+
+// A chain split across query round-trips must keep the ancestor guarantee:
+// hops learned via the derived path seed the running max with the parent
+// entry's remaining life (derivedReach), so a short-TTL tail learned from a
+// later response outlives its own record for as long as the already-learned
+// ancestor's records can still point clients at it.
+func TestHandleDNSQuery_CNAMEDerivedSeedsAncestorReach(t *testing.T) {
+	cfg := config.NewConfigManager()
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "allowed.example.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	mockFw := firewall.NewMockFirewall(t)
+	server := newTestServer(t, cfg, mockFw)
+	server.filterQueries = true
+
+	// The parent hop was learned from an earlier response and still has ~10
+	// minutes of life (e.g. a long ancestor CNAME TTL).
+	server.cnameAllowed.Put("hop1.example.net",
+		derivedAllow{chain: []string{"allowed.example.com", "hop1.example.net"}}, 600*time.Second)
+
+	// The client now queries the hop directly; the split chain's next
+	// response carries only the short-TTL tail.
+	const qname = "hop1.example.net."
+	resp := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: 7100, Response: true, Rcode: dns.RcodeSuccess},
+		Question: []dns.Question{{Name: qname, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+		Answer: []dns.RR{&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: qname, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 9},
+			Target: "tail.example.net.",
+		}},
+	}
+	seedCachedResponse(server, qname, resp)
+
+	query := new(dns.Msg)
+	query.SetQuestion(qname, dns.TypeA)
+	query.Id = 7101
+	w := &MockResponseWriter{}
+	w.On("WriteMsg", mock.AnythingOfType("*dns.Msg")).Return(nil).Once()
+	server.handleDNSQuery(w, query)
+	w.AssertExpectations(t)
+
+	// The tail must inherit the parent's remaining ~600s, not its own
+	// 9s→30s floored TTL.
+	exp, ok := server.cnameAllowed.peekExpiry("tail.example.net")
+	require.True(t, ok, "derived response must learn the tail")
+	remaining := time.Until(exp)
+	assert.Greater(t, remaining, 550*time.Second, "tail must seed from the parent entry's remaining life")
+	assert.LessOrEqual(t, remaining, 600*time.Second, "tail must not outlive the parent's remaining life")
+
+	// Attribution still extends the parent's chain down to the tail.
+	entry, ok := server.cnameAllowed.Get("tail.example.net")
+	require.True(t, ok)
+	assert.Equal(t, []string{"allowed.example.com", "hop1.example.net", "tail.example.net"}, entry.chain)
 }
 
 // cnameChainTargets must follow only the chain rooted at the query name, carry


### PR DESCRIPTION
Fixes #87.

A client reaches a CNAME hop by following its ancestors' cached records, so it can keep querying that hop directly for as long as the longest-lived record above it survives. Learning each hop for its own CNAME TTL let a short-TTL tail under a long-TTL ancestor — 9s under ~16m on the observed `akadns.net` chain — expire into REFUSED while resolver caches still pointed clients at it, with no origin re-query to re-learn it. The `dotnet` CRL fetch in the issue only recovered because a second chain (`crl3.digicert.com`) re-learned the same tail 3ms later; the spurious `dns_blocked` events reached the SaaS as apparent policy violations.

## Changes

**Running-max chain TTL** (`pkg/dns/server.go` learning loop): each target's derived allow now covers the running max of the *effective* (floored) CNAME TTLs from the origin down to it — the window in which cache can still point a client at it. Changes only *how long*, never *which names*: `cnameChainTargets` still walks only the chain rooted at the query name, deny rules still precede the `cnameAllowed` lookup in `isQueryAllowed`, and firewall IP enforcement is untouched.

The invariant is enforced at every layer that can affect an entry's lifetime, not just single-response learn time:

- **Extend-only merge expiry** (`pkg/dns/lru.go`): `Merge` keeps the later of the existing and incoming expiry for a live entry, so a partial-chain re-learn with a smaller running max composes the value but can't truncate a lifetime an earlier response established.
- **Derived reach seeding**: the split-chain path seeds the running max with the parent entry's remaining life (new `GetWithExpiry`), so the ancestor guarantee survives chains split across query round-trips.
- **Effective-TTL max**: the max runs over `derivedCNAMETTL`-floored per-hop TTLs, so the TTL-0→300s defeat-caching accommodation reaches descendants; sub-30s TTLs floor to `minDerivedCNAMETTL` (a TTL-1 chain previously yielded a 1-second allow window).
- **Cap**: `maxDerivedCNAMETTL` (1 day) bounds the reach so one huge or crafted ancestor TTL can't pin a whole chain near-indefinitely.

**Release version stamping fix** (`Makefile`, folded in per review): `CI_VERSION` was applied after `LDFLAGS`' immediate expansion had baked in `develop`, and `-X` targeted `main.Version` while `cargowall.go` declares unexported `main.version` — the linker silently ignored it, so every build printed `dev`. Verified by dry-run: `make -n build CI_VERSION=v9.9.9` now emits `-X main.version=v9.9.9`.

## Tests

- `TestHandleDNSQuery_CNAMEChainTTLRunningMax`: table-driven over descending (the #87 shape), ascending, and floored (TTL-0/sub-30s under nonzero ancestor) chains; a short A record in each case still guards the response-wide-min regression.
- `TestHandleDNSQuery_CNAMEDerivedSeedsAncestorReach`: split-chain tail inherits the parent entry's remaining ~600s instead of its own 9s, with chain attribution intact.
- `TestLRUCache_MergeExpiryExtendOnly`: shorter re-merge composes but can't truncate; longer extends; never-expires wins both directions.
- `TestDerivedCNAMETTL` extended for the 30s floor and boundary.

Verified locally via `GOOS=linux go build` / `go vet` / `staticcheck` / `gofumpt` (tests are linux-only; CI runs them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)