### PR TITLE
#89 flush cache at eBPF attach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,22 @@ jobs:
       - name: Make binary executable
         run: chmod +x bin/cargowall
 
+      - name: Warm systemd-resolved cache before attach (reproduce #89)
+        run: |
+          # GitHub's Azure runners resolve via systemd-resolved (127.0.0.53).
+          # Populate its stub cache with a wildcard-matched name BEFORE cargowall
+          # attaches. The concrete name can't be pre-tracked, so only the
+          # attach-time cache flush makes the later getaddrinfo miss the stub and
+          # re-resolve through the proxy — where **.githubusercontent.com matches
+          # and the IP is allowed with attribution. Without the flush the warm
+          # entry is served invisibly and the "hostname pattern" curl below is
+          # blocked as a bare IP. Best-effort so runners without systemd-resolved
+          # simply fall back to the cold-cache path.
+          resolvectl query raw.githubusercontent.com 2>/dev/null \
+            || getent ahosts raw.githubusercontent.com \
+            || true
+          echo "Warmed resolver cache for raw.githubusercontent.com"
+
       - name: Start CargoWall via Action
         uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
         with:
@@ -159,8 +175,13 @@ jobs:
 
       - name: Test allowed connection via hostname pattern
         run: |
+          # Doubles as the #89 regression check: raw.githubusercontent.com was
+          # warmed into the systemd-resolved stub cache before attach (step
+          # above). If the attach-time cache flush regresses, this getaddrinfo
+          # is served invisibly from the warm stub, the proxy never sees the
+          # name, and the connection is blocked as a bare IP — failing here.
           curl -sf --connect-timeout 10 --max-time 30 https://raw.githubusercontent.com/github/gitignore/main/README.md > /dev/null
-          echo "✅ raw.githubusercontent.com allowed via **.githubusercontent.com pattern"
+          echo "✅ raw.githubusercontent.com allowed via **.githubusercontent.com pattern (warm-cache re-resolved through proxy)"
 
       - name: Test blocked connection
         run: |
@@ -732,6 +753,24 @@ jobs:
       - name: Show startup log (debug aid)
         if: always()
         run: sudo cat /tmp/cargowall.log || true
+
+      - name: Verify systemd-resolved cache flush ran at attach (#89)
+        run: |
+          # On the Azure runner the client resolver is systemd-resolved, whose
+          # warm stub cache used to serve pre-attach answers invisibly (#89).
+          # With the DNS redirect active (--gitlab-ci preset), cargowall flushes
+          # that cache at attach so future lookups traverse the proxy. Assert the
+          # FlushResolvedCache path executed — the flush itself on a resolved
+          # host, or the documented best-effort skip elsewhere.
+          if sudo grep -q "Flushed systemd-resolved DNS cache" /tmp/cargowall.log; then
+            echo "✅ resolved cache flushed at attach"
+          elif sudo grep -qE "systemd-resolved not running|resolvectl not found" /tmp/cargowall.log; then
+            echo "ℹ️ systemd-resolved not in use on this runner; flush correctly skipped"
+          else
+            echo "❌ neither flush nor skip logged — FlushResolvedCache path not reached"
+            sudo grep -iE "resolv|flush|dns redirect" /tmp/cargowall.log || true
+            exit 1
+          fi
 
       - name: Verify pidfile written
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,20 +168,24 @@ jobs:
           binary-path: ./bin/cargowall
           debug: true
 
+      - name: Test allowed connection via hostname pattern
+        run: |
+          # Runs FIRST among the connection tests: it doubles as the #89
+          # regression check for raw.githubusercontent.com, which was warmed
+          # into the systemd-resolved stub cache before attach (step above).
+          # Keeping it first minimizes the warm→request window so a short record
+          # TTL can't expire the entry and silently degrade this to the ordinary
+          # cold-cache path. If the attach-time cache flush regresses, this
+          # getaddrinfo is served invisibly from the warm stub, the proxy never
+          # sees the name, and the connection is blocked as a bare IP — failing
+          # here.
+          curl -sf --connect-timeout 10 --max-time 30 https://raw.githubusercontent.com/github/gitignore/main/README.md > /dev/null
+          echo "✅ raw.githubusercontent.com allowed via **.githubusercontent.com pattern (warm-cache re-resolved through proxy)"
+
       - name: Test allowed connection
         run: |
           curl -sf --connect-timeout 10 --max-time 30 https://github.com > /dev/null
           echo "✅ github.com allowed"
-
-      - name: Test allowed connection via hostname pattern
-        run: |
-          # Doubles as the #89 regression check: raw.githubusercontent.com was
-          # warmed into the systemd-resolved stub cache before attach (step
-          # above). If the attach-time cache flush regresses, this getaddrinfo
-          # is served invisibly from the warm stub, the proxy never sees the
-          # name, and the connection is blocked as a bare IP — failing here.
-          curl -sf --connect-timeout 10 --max-time 30 https://raw.githubusercontent.com/github/gitignore/main/README.md > /dev/null
-          echo "✅ raw.githubusercontent.com allowed via **.githubusercontent.com pattern (warm-cache re-resolved through proxy)"
 
       - name: Test blocked connection
         run: |

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -102,6 +102,10 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 
 	var dnsServer *dns.Server
 	var dockerBridgeIP string
+	// Tracks whether the iptables DNS redirect is actually in place, so the
+	// post-snapshot systemd-resolved cache flush runs only when there is a
+	// proxy for future upstream lookups to traverse.
+	var dnsRedirectActive bool
 	if !cmd.DisableDNSTracking {
 		// Get upstream DNS server (defaults to Kubernetes DNS)
 		upstream := cmd.DNSUpstream
@@ -174,6 +178,7 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 			if err := network.SetupDNSRedirect(logger); err != nil {
 				logger.Warn("Failed to set up DNS redirect (iptables)", "error", err)
 			} else {
+				dnsRedirectActive = true
 				defer func() {
 					if err := network.TeardownDNSRedirect(logger); err != nil {
 						logger.Warn("Failed to tear down DNS redirect", "error", err)
@@ -421,6 +426,24 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		if cmd.PrepopulateDNSCache {
 			reverseDNSExistingConnections(existing, configMgr, cacheResolver, logger)
 			prePopulateDNSCache(configMgr, dnsServer, cacheResolver, logger)
+		}
+
+		// Flush systemd-resolved's cache now that the redirect is installed
+		// and every warm-cache read above (existing-connection reverse DNS +
+		// Phase 1 snapshot) has run against it. Flushing forces all future
+		// lookups — from any process, including ones that populated the stub
+		// cache before cargowall attached — to miss 127.0.0.53 and go
+		// upstream, where the redirect routes them through the proxy for
+		// suffix-rule matching, IP allowlisting, and hostname attribution.
+		// Without this, a warm stub cache hit is served invisibly and the
+		// connection arrives as an unattributed bare IP (deny-by-default).
+		// Gated on the redirect being live: with no proxy in the upstream
+		// path, flushing would only churn the cache for no benefit.
+		// Non-fatal — hosts without systemd-resolved work via the redirect.
+		if dnsRedirectActive {
+			if err := network.FlushResolvedCache(logger); err != nil {
+				logger.Warn("Failed to flush systemd-resolved cache (non-fatal)", "error", err)
+			}
 		}
 
 		// Gate AFTER pre-population so reverse-DNS attribution is available.

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -441,7 +441,7 @@ func StartCargoWall(cmd *StartCmd, hooks *StartHooks) error {
 		// path, flushing would only churn the cache for no benefit.
 		// Non-fatal — hosts without systemd-resolved work via the redirect.
 		if dnsRedirectActive {
-			if err := network.FlushResolvedCache(logger); err != nil {
+			if err := network.FlushResolvedCache(ctx, logger); err != nil {
 				logger.Warn("Failed to flush systemd-resolved cache (non-fatal)", "error", err)
 			}
 		}

--- a/pkg/network/dns_redirect.go
+++ b/pkg/network/dns_redirect.go
@@ -56,6 +56,32 @@ func SetupDNSRedirect(logger *slog.Logger) error {
 	return nil
 }
 
+// FlushResolvedCache clears systemd-resolved's DNS cache via
+// `resolvectl flush-caches`. Once the DNS redirect is installed, flushing
+// forces every subsequent lookup — including from processes that warmed the
+// 127.0.0.53 stub cache before cargowall attached — to miss the stub and go
+// upstream, where the redirect routes it through the proxy. That is where
+// suffix/wildcard rules match, resolved IPs get firewall-allowed, and
+// hostname attribution is retained; a warm stub cache hit never travels
+// upstream, so the proxy never sees the name and the connection lands as an
+// unattributed bare IP (deny-by-default).
+//
+// Best-effort: on hosts without systemd-resolved there is no stub cache to
+// flush and the redirect alone suffices, so a missing resolvectl is not an
+// error. A genuine flush failure is returned for the caller to log.
+func FlushResolvedCache(logger *slog.Logger) error {
+	path, err := exec.LookPath("resolvectl")
+	if err != nil {
+		logger.Debug("resolvectl not found; skipping systemd-resolved cache flush")
+		return nil
+	}
+	if out, err := exec.Command(path, "flush-caches").CombinedOutput(); err != nil {
+		return fmt.Errorf("resolvectl flush-caches failed: %w (output: %s)", err, out)
+	}
+	logger.Info("Flushed systemd-resolved DNS cache")
+	return nil
+}
+
 // TeardownDNSRedirect removes the iptables DNAT rules added by SetupDNSRedirect.
 func TeardownDNSRedirect(logger *slog.Logger) error {
 	var lastErr error

--- a/pkg/network/dns_redirect.go
+++ b/pkg/network/dns_redirect.go
@@ -99,16 +99,32 @@ func FlushResolvedCache(ctx context.Context, logger *slog.Logger) error {
 	}
 
 	// resolvectl can be installed on hosts that don't actually run
-	// systemd-resolved (a different resolver is in use). Flushing there only
-	// errors, so skip quietly rather than warn on every startup.
+	// systemd-resolved (a different resolver is in use); its runtime dir is
+	// absent there, so skip quietly rather than warn on every startup. Only a
+	// genuine "not there" is benign — a stat failure such as EACCES/EIO is real
+	// and surfaced, mirroring the LookPath classification above (otherwise a
+	// host where resolved *is* running would be misreported as a correct skip).
 	if _, err := os.Stat(resolvedRuntimeDir); err != nil {
-		logger.Debug("systemd-resolved not running; skipping cache flush", "probe", resolvedRuntimeDir)
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			logger.Debug("systemd-resolved not running; skipping cache flush", "probe", resolvedRuntimeDir)
+			return nil
+		}
+		return fmt.Errorf("probing %s failed: %w", resolvedRuntimeDir, err)
 	}
 
 	flushCtx, cancel := context.WithTimeout(ctx, flushResolvedTimeout)
 	defer cancel()
-	if out, err := exec.CommandContext(flushCtx, path, "flush-caches").CombinedOutput(); err != nil {
+	flush := exec.CommandContext(flushCtx, path, "flush-caches")
+	// WaitDelay bounds CombinedOutput's Wait after the deadline kills the
+	// process: without it, Wait blocks until every inheritor of the stdout/
+	// stderr pipes exits, so the timeout would rest on resolvectl never leaving
+	// a lingering child holding them.
+	flush.WaitDelay = time.Second
+	if out, err := flush.CombinedOutput(); err != nil {
+		// Name the deadline rather than surfacing a bare "signal: killed".
+		if ctxErr := flushCtx.Err(); ctxErr != nil {
+			return fmt.Errorf("resolvectl flush-caches timed out after %s: %w", flushResolvedTimeout, ctxErr)
+		}
 		return fmt.Errorf("resolvectl flush-caches failed: %w (output: %s)", err, out)
 	}
 	logger.Info("Flushed systemd-resolved DNS cache")

--- a/pkg/network/dns_redirect.go
+++ b/pkg/network/dns_redirect.go
@@ -17,9 +17,13 @@
 package network
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"time"
 )
 
 // DNSProxyFWMark is the firewall mark applied to the DNS proxy's own upstream
@@ -56,6 +60,17 @@ func SetupDNSRedirect(logger *slog.Logger) error {
 	return nil
 }
 
+// resolvedRuntimeDir exists only while systemd-resolved is running. Its
+// presence is the signal that tells "resolved not in use" (a quiet skip) apart
+// from "resolved running but the flush genuinely failed" (surfaced to the
+// caller). A var so tests can point it at a controllable path.
+var resolvedRuntimeDir = "/run/systemd/resolve"
+
+// flushResolvedTimeout bounds the resolvectl call so a wedged systemd-resolved
+// (or its D-Bus endpoint) cannot stall startup before the eBPF program
+// attaches and the firewall begins enforcing. A var so tests can shorten it.
+var flushResolvedTimeout = 5 * time.Second
+
 // FlushResolvedCache clears systemd-resolved's DNS cache via
 // `resolvectl flush-caches`. Once the DNS redirect is installed, flushing
 // forces every subsequent lookup — including from processes that warmed the
@@ -66,16 +81,34 @@ func SetupDNSRedirect(logger *slog.Logger) error {
 // upstream, so the proxy never sees the name and the connection lands as an
 // unattributed bare IP (deny-by-default).
 //
-// Best-effort: on hosts without systemd-resolved there is no stub cache to
-// flush and the redirect alone suffices, so a missing resolvectl is not an
-// error. A genuine flush failure is returned for the caller to log.
-func FlushResolvedCache(logger *slog.Logger) error {
+// Best-effort with two quiet skips (return nil, log at Debug): resolvectl not
+// installed, or systemd-resolved not running — in both cases there is no stub
+// cache to flush and the redirect alone suffices. Everything else is surfaced
+// to the caller: a non-not-found lookup error (e.g. a non-executable resolvectl
+// on PATH), a non-zero flush exit, or the bounded call timing out.
+func FlushResolvedCache(ctx context.Context, logger *slog.Logger) error {
 	path, err := exec.LookPath("resolvectl")
 	if err != nil {
-		logger.Debug("resolvectl not found; skipping systemd-resolved cache flush")
+		// Only genuine not-installed is benign; a permission or other PATH
+		// resolution failure is real and must not silently skip the flush.
+		if errors.Is(err, exec.ErrNotFound) {
+			logger.Debug("resolvectl not found; skipping systemd-resolved cache flush")
+			return nil
+		}
+		return fmt.Errorf("locating resolvectl failed: %w", err)
+	}
+
+	// resolvectl can be installed on hosts that don't actually run
+	// systemd-resolved (a different resolver is in use). Flushing there only
+	// errors, so skip quietly rather than warn on every startup.
+	if _, err := os.Stat(resolvedRuntimeDir); err != nil {
+		logger.Debug("systemd-resolved not running; skipping cache flush", "probe", resolvedRuntimeDir)
 		return nil
 	}
-	if out, err := exec.Command(path, "flush-caches").CombinedOutput(); err != nil {
+
+	flushCtx, cancel := context.WithTimeout(ctx, flushResolvedTimeout)
+	defer cancel()
+	if out, err := exec.CommandContext(flushCtx, path, "flush-caches").CombinedOutput(); err != nil {
 		return fmt.Errorf("resolvectl flush-caches failed: %w (output: %s)", err, out)
 	}
 	logger.Info("Flushed systemd-resolved DNS cache")

--- a/pkg/network/dns_redirect_test.go
+++ b/pkg/network/dns_redirect_test.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -26,16 +27,17 @@ import (
 	"time"
 )
 
-// writeFakeResolvectl drops an executable `resolvectl` into a fresh temp dir
-// whose body is the given /bin/sh script, and returns the dir so the caller can
-// make it the sole PATH entry.
-func writeFakeResolvectl(t *testing.T, script string) string {
+// installFakeResolvectl drops an executable `resolvectl` running the given
+// /bin/sh script into a fresh temp dir and makes it the FIRST entry on PATH.
+// The existing PATH is preserved after it so LookPath resolves the fake yet the
+// script can still invoke real utilities (e.g. `sleep`).
+func installFakeResolvectl(t *testing.T, script string) {
 	t.Helper()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "resolvectl"), []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
 		t.Fatalf("write fake resolvectl: %v", err)
 	}
-	return dir
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func discardLogger() *slog.Logger {
@@ -62,7 +64,7 @@ func TestFlushResolvedCache_NotInstalled(t *testing.T) {
 // TestFlushResolvedCache_ResolvedNotRunning: resolvectl present but the runtime
 // dir is absent → quiet skip, and the fake (which would exit 1) must not run.
 func TestFlushResolvedCache_ResolvedNotRunning(t *testing.T) {
-	t.Setenv("PATH", writeFakeResolvectl(t, "exit 1"))
+	installFakeResolvectl(t, "exit 1")
 	prev := resolvedRuntimeDir
 	resolvedRuntimeDir = filepath.Join(t.TempDir(), "absent")
 	t.Cleanup(func() { resolvedRuntimeDir = prev })
@@ -74,7 +76,7 @@ func TestFlushResolvedCache_ResolvedNotRunning(t *testing.T) {
 
 // TestFlushResolvedCache_FlushFails: resolved running + non-zero exit → error.
 func TestFlushResolvedCache_FlushFails(t *testing.T) {
-	t.Setenv("PATH", writeFakeResolvectl(t, "echo boom >&2; exit 1"))
+	installFakeResolvectl(t, "echo boom >&2; exit 1")
 	withResolvedRunning(t)
 
 	if err := FlushResolvedCache(context.Background(), discardLogger()); err == nil {
@@ -84,7 +86,7 @@ func TestFlushResolvedCache_FlushFails(t *testing.T) {
 
 // TestFlushResolvedCache_Success: resolved running + zero exit → nil.
 func TestFlushResolvedCache_Success(t *testing.T) {
-	t.Setenv("PATH", writeFakeResolvectl(t, "exit 0"))
+	installFakeResolvectl(t, "exit 0")
 	withResolvedRunning(t)
 
 	if err := FlushResolvedCache(context.Background(), discardLogger()); err != nil {
@@ -95,7 +97,7 @@ func TestFlushResolvedCache_Success(t *testing.T) {
 // TestFlushResolvedCache_Timeout: a wedged resolvectl is killed at the deadline
 // and surfaced as an error rather than hanging startup.
 func TestFlushResolvedCache_Timeout(t *testing.T) {
-	t.Setenv("PATH", writeFakeResolvectl(t, "sleep 5"))
+	installFakeResolvectl(t, "sleep 5")
 	withResolvedRunning(t)
 	prev := flushResolvedTimeout
 	flushResolvedTimeout = 50 * time.Millisecond
@@ -107,6 +109,9 @@ func TestFlushResolvedCache_Timeout(t *testing.T) {
 	case err := <-done:
 		if err == nil {
 			t.Fatal("expected timeout error, got nil")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected a deadline-exceeded error naming the timeout, got %v", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("FlushResolvedCache did not honor its timeout")

--- a/pkg/network/dns_redirect_test.go
+++ b/pkg/network/dns_redirect_test.go
@@ -1,0 +1,114 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package network
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeFakeResolvectl drops an executable `resolvectl` into a fresh temp dir
+// whose body is the given /bin/sh script, and returns the dir so the caller can
+// make it the sole PATH entry.
+func writeFakeResolvectl(t *testing.T, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "resolvectl"), []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake resolvectl: %v", err)
+	}
+	return dir
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// withResolvedRunning points resolvedRuntimeDir at an existing dir so the
+// "resolved running" gate passes, restoring it on cleanup.
+func withResolvedRunning(t *testing.T) {
+	t.Helper()
+	prev := resolvedRuntimeDir
+	resolvedRuntimeDir = t.TempDir()
+	t.Cleanup(func() { resolvedRuntimeDir = prev })
+}
+
+// TestFlushResolvedCache_NotInstalled: resolvectl absent from PATH → quiet skip.
+func TestFlushResolvedCache_NotInstalled(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir, no resolvectl
+	if err := FlushResolvedCache(context.Background(), discardLogger()); err != nil {
+		t.Fatalf("expected nil when resolvectl not installed, got %v", err)
+	}
+}
+
+// TestFlushResolvedCache_ResolvedNotRunning: resolvectl present but the runtime
+// dir is absent → quiet skip, and the fake (which would exit 1) must not run.
+func TestFlushResolvedCache_ResolvedNotRunning(t *testing.T) {
+	t.Setenv("PATH", writeFakeResolvectl(t, "exit 1"))
+	prev := resolvedRuntimeDir
+	resolvedRuntimeDir = filepath.Join(t.TempDir(), "absent")
+	t.Cleanup(func() { resolvedRuntimeDir = prev })
+
+	if err := FlushResolvedCache(context.Background(), discardLogger()); err != nil {
+		t.Fatalf("expected nil when systemd-resolved not running, got %v", err)
+	}
+}
+
+// TestFlushResolvedCache_FlushFails: resolved running + non-zero exit → error.
+func TestFlushResolvedCache_FlushFails(t *testing.T) {
+	t.Setenv("PATH", writeFakeResolvectl(t, "echo boom >&2; exit 1"))
+	withResolvedRunning(t)
+
+	if err := FlushResolvedCache(context.Background(), discardLogger()); err == nil {
+		t.Fatal("expected error when resolvectl flush-caches fails, got nil")
+	}
+}
+
+// TestFlushResolvedCache_Success: resolved running + zero exit → nil.
+func TestFlushResolvedCache_Success(t *testing.T) {
+	t.Setenv("PATH", writeFakeResolvectl(t, "exit 0"))
+	withResolvedRunning(t)
+
+	if err := FlushResolvedCache(context.Background(), discardLogger()); err != nil {
+		t.Fatalf("expected nil on successful flush, got %v", err)
+	}
+}
+
+// TestFlushResolvedCache_Timeout: a wedged resolvectl is killed at the deadline
+// and surfaced as an error rather than hanging startup.
+func TestFlushResolvedCache_Timeout(t *testing.T) {
+	t.Setenv("PATH", writeFakeResolvectl(t, "sleep 5"))
+	withResolvedRunning(t)
+	prev := flushResolvedTimeout
+	flushResolvedTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { flushResolvedTimeout = prev })
+
+	done := make(chan error, 1)
+	go func() { done <- FlushResolvedCache(context.Background(), discardLogger()) }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected timeout error, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("FlushResolvedCache did not honor its timeout")
+	}
+}


### PR DESCRIPTION
Closes #89.

## Problem

On VM-style runners (reported case: a GitHub Actions runner on Azure, enforce mode), systemd-resolved's stub cache serves pre-attach answers **invisibly**. The DNS redirect intercepts resolved's *upstream* queries, but a stub cache hit at `127.0.0.53` never goes upstream — so the proxy never sees the name, no hostname↔IP mapping is learned, and the connection arrives as a bare IP → deny-by-default. The result was unattributed bare-IP blocks (e.g. the runner's results uploader to `productionresultssa*.blob.core.windows.net`) shipped to the SaaS as apparent policy violations. Whether a run was hit was a TTL lottery on whether resolved's cache happened to be warm.

Neither existing mitigation reaches this: the pre-existing-connection scan only covers sockets already open at attach, and the Phase-1 cache snapshot can only query *tracked* hostnames — a wildcard/suffix-matched name (`blob.core.windows.net`) is unknowable in advance, since the concrete storage-account name only exists once someone resolves it.

## Fix

Flush systemd-resolved's cache once the redirect is in place, so every subsequent lookup from any process misses the stub, goes upstream, and traverses the proxy — where suffix rules match, IPs are firewall-allowed, and attribution is kept.

Ordering (`cmd/start.go`):

```
install DNS redirect → snapshot tracked hostnames (warm cache) → resolvectl flush-caches
```

The snapshot and existing-connection reverse-DNS run against the warm cache **first** (they need the currently-in-use IPs), then the flush makes all future resolution visible. Gated on the redirect actually being installed (`dnsRedirectActive`) — with no proxy in the upstream path, flushing would only churn the cache. A full-cache flush is deliberate: a targeted flush is structurally impossible (the account name only exists post-resolution — see #89's rejected alternatives).

## Hardening (from `/code-review` + PR review)

- **Bounded** — the `resolvectl flush-caches` call runs under `exec.CommandContext` with a 5s deadline (threaded from the startup `ctx`), so a wedged systemd-resolved / D-Bus can't stall startup before the eBPF program attaches and enforcement begins.
- **Error classification** — only the genuine not-installed case (`errors.Is(err, exec.ErrNotFound)`) is swallowed; other `LookPath` failures (e.g. a non-executable `resolvectl` on PATH) surface to the caller instead of silently skipping the flush.
- **Quiet where expected** — when `resolvectl` is present but systemd-resolved isn't running (probed via `/run/systemd/resolve`), skip at `Debug`, not `Warn`, so hosts using a different resolver don't warn on every startup.
- **Tests** — new `pkg/network/dns_redirect_test.go` covers not-installed, not-running, flush-failure, success, and the timeout bound.

## Behavior notes

- **Non-fatal everywhere** — hosts without systemd-resolved already work via the redirect alone; a flush failure is logged and startup continues.
- **k8s sidecar: inert by design** — the cargowall container has no systemd-resolved, so both guards skip. The bug doesn't exist under cluster DNS anyway: pods resolve via a non-loopback ClusterIP / NodeLocal address, which the redirect DNATs straight to the proxy, so every query is already seen.
- **Residual gap (accepted, per #89)** — a process that resolved pre-attach and holds the IP in app memory with no open socket (JVM-style in-process caching) isn't covered; the escalation path is SNI-based verdicting, not worth it until the flush proves insufficient.

## Testing

**Unit** — on real linux (arm64): `go build ./...`, `go vet`, `staticcheck`, `make fmt-check`, and full `go test ./...` all green, including the 5 new `pkg/network` tests (the timeout test confirms the call is killed at its deadline).

**Integration (`ci.yml`, on the Azure runner where systemd-resolved is the real resolver — the #89 environment)**:
- *Enforce Mode* — `raw.githubusercontent.com` is warmed into the systemd-resolved stub cache **before** cargowall attaches, so the existing "allowed via `**.githubusercontent.com` pattern" curl doubles as a #89 regression check: if the attach-time flush regresses, the warm stub answer is served invisibly and the connection is blocked as a bare IP, failing the step.
- *GitLab CI mode* — asserts the `FlushResolvedCache` path actually executed at startup by grepping the captured debug log for the flush line (or the documented best-effort skip on hosts without systemd-resolved).

Both are additive and low-flake — the enforce check only fails if the flush is removed, and the gitlab-ci check reads a log the job already captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
