### PR TITLE
#92 report the cargowall version to the SaaS

### DIFF
--- a/cargowall.go
+++ b/cargowall.go
@@ -44,6 +44,7 @@ func main() {
 		return cmd.StartCargoWall(c, hooks)
 	}
 	cli.Start.Version = version
+	cli.Summary.Version = version
 
 	err := ctx.Run(&cli.Globals)
 	ctx.FatalIfErrorf(err)

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -34,10 +34,19 @@ import (
 // SaaS API. The endpoint returns the merged policy (org defaults + repo
 // overrides + job-level overrides) as a CargoWallPolicy protobuf message
 // serialised as JSON.
-func fetchPolicyFromAPI(ctx context.Context, apiUrl, token, jobKey string) (*cargowallv1pb.CargoWallPolicy, error) {
+func fetchPolicyFromAPI(ctx context.Context, apiUrl, token, jobKey, version string) (*cargowallv1pb.CargoWallPolicy, error) {
 	endpoint := strings.TrimRight(apiUrl, "/") + "/api/cargowall/v1/action/policy"
+	// Empty params are omitted entirely rather than sent blank, so the server
+	// can distinguish "not reported" from "reported as empty".
+	q := url.Values{}
 	if jobKey != "" {
-		endpoint += "?job_key=" + url.QueryEscape(jobKey)
+		q.Set("job_key", jobKey)
+	}
+	if version != "" {
+		q.Set("version", version)
+	}
+	if len(q) > 0 {
+		endpoint += "?" + q.Encode()
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)

--- a/cmd/api_test.go
+++ b/cmd/api_test.go
@@ -32,28 +32,36 @@ import (
 const policyEndpoint = "/api/cargowall/v1/action/policy"
 
 // policyServer returns an httptest server that serves the given JSON body for
-// the policy endpoint. It asserts the request method, path, job_key query and
-// bearer token match what fetchPolicyFromAPI is expected to send, so the tests
-// also catch endpoint regressions.
-func policyServer(t *testing.T, wantJobKey, body string) *httptest.Server {
+// the policy endpoint. It asserts the request method, path, job_key/version
+// query and bearer token match what fetchPolicyFromAPI is expected to send, so
+// the tests also catch endpoint regressions.
+func policyServer(t *testing.T, wantJobKey, wantVersion, body string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, policyEndpoint, r.URL.Path)
-		// Assert presence/absence explicitly: fetchPolicyFromAPI must omit the
-		// job_key param entirely when no job key is set, not send it empty.
-		gotJobKey, present := r.URL.Query()["job_key"]
-		if wantJobKey == "" {
-			assert.False(t, present, "job_key must be absent when no job key is set")
-		} else {
-			assert.Equal(t, []string{wantJobKey}, gotJobKey)
-		}
+		// Assert presence/absence explicitly: fetchPolicyFromAPI must omit an
+		// unset param entirely, not send it empty.
+		assertQueryParam(t, r, "job_key", wantJobKey)
+		assertQueryParam(t, r, "version", wantVersion)
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	}))
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// assertQueryParam asserts that name is absent when want is empty, and carries
+// exactly want otherwise.
+func assertQueryParam(t *testing.T, r *http.Request, name, want string) {
+	t.Helper()
+	got, present := r.URL.Query()[name]
+	if want == "" {
+		assert.False(t, present, "%s must be absent when unset", name)
+		return
+	}
+	assert.Equal(t, []string{want}, got)
 }
 
 // TestFetchPolicyFromAPI_IgnoresUnknownField guards against the forward-compat
@@ -66,9 +74,9 @@ func TestFetchPolicyFromAPI_IgnoresUnknownField(t *testing.T) {
 		"future_feature": {"enabled": true, "level": 3},
 		"another_unknown": "ignore me"
 	}`
-	srv := policyServer(t, "job-123", body)
+	srv := policyServer(t, "job-123", "v1.2.3", body)
 
-	policy, err := fetchPolicyFromAPI(context.Background(), srv.URL, "test-token", "job-123")
+	policy, err := fetchPolicyFromAPI(context.Background(), srv.URL, "test-token", "job-123", "v1.2.3")
 	require.NoError(t, err, "unknown fields must not cause the policy to be dropped")
 	require.NotNil(t, policy)
 	assert.Equal(t, datapb.CargoWallMode_CARGO_WALL_MODE_AUDIT, policy.Mode)
@@ -83,11 +91,23 @@ func TestFetchPolicyFromAPI_IgnoresUnknownEnumValue(t *testing.T) {
 		"mode": "CARGO_WALL_MODE_FUTURE_VALUE",
 		"default_action": "CARGO_WALL_ACTION_TYPE_ALLOW"
 	}`
-	srv := policyServer(t, "", body)
+	srv := policyServer(t, "", "", body)
 
-	policy, err := fetchPolicyFromAPI(context.Background(), srv.URL, "test-token", "")
+	policy, err := fetchPolicyFromAPI(context.Background(), srv.URL, "test-token", "", "")
 	require.NoError(t, err, "unknown enum names must not cause the policy to be dropped")
 	require.NotNil(t, policy)
 	assert.Equal(t, datapb.CargoWallMode_CARGO_WALL_MODE_UNSPECIFIED, policy.Mode)
 	assert.Equal(t, datapb.CargoWallActionType_CARGO_WALL_ACTION_TYPE_ALLOW, policy.DefaultAction)
+}
+
+// TestFetchPolicyFromAPI_ReportsVersionWithoutJobKey covers the mixed case: the
+// agent reports its version (#92) on a run with no job key, so version must
+// still be sent and job_key must stay absent.
+func TestFetchPolicyFromAPI_ReportsVersionWithoutJobKey(t *testing.T) {
+	srv := policyServer(t, "", "v1.2.3", `{"mode": "CARGO_WALL_MODE_AUDIT"}`)
+
+	policy, err := fetchPolicyFromAPI(context.Background(), srv.URL, "test-token", "", "v1.2.3")
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.Equal(t, datapb.CargoWallMode_CARGO_WALL_MODE_AUDIT, policy.Mode)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -590,8 +590,8 @@ func loadCIConfig(ctx context.Context, cmd *StartCmd, configMgr *config.Manager,
 			configMgr.EnsureHostnameAllowed(u.Hostname(), []config.Port{config.PortHTTPS}, config.AutoAddedTypeCodeCargoService)
 		}
 
-		logger.Info("Fetching policy from CodeCargo API", "api_url", cmd.ApiUrl, "job_key", cmd.JobKey)
-		policy, err := fetchPolicyFromAPI(ctx, cmd.ApiUrl, cmd.Token, cmd.JobKey)
+		logger.Info("Fetching policy from CodeCargo API", "api_url", cmd.ApiUrl, "job_key", cmd.JobKey, "version", cmd.Version)
+		policy, err := fetchPolicyFromAPI(ctx, cmd.ApiUrl, cmd.Token, cmd.JobKey, cmd.Version)
 		if err != nil {
 			logger.Warn("API policy fetch failed, falling back to env/file config", "error", err)
 		} else {

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -39,6 +39,8 @@ import (
 
 // SummaryCmd generates a markdown summary correlating audit events with GitHub Actions steps
 type SummaryCmd struct {
+	Version string `kong:"-"` // Version passed from main
+
 	AuditLog string `help:"Path to audit log JSON file" required:""`
 	Steps    string `help:"JSON array of step timing from GitHub API" required:""`
 
@@ -639,6 +641,10 @@ func (c *SummaryCmd) pushToApi(stepEvents []StepEvents, steps []GitHubStep) (str
 
 	if c.JobRunId != 0 {
 		req.JobRunId = &c.JobRunId
+	}
+
+	if c.Version != "" {
+		req.Version = &c.Version
 	}
 
 	// Set timestamps from first/last events

--- a/cmd/summary_test.go
+++ b/cmd/summary_test.go
@@ -814,6 +814,44 @@ func TestPushToApi_IgnoresUnknownResponseField(t *testing.T) {
 	assert.Equal(t, "https://app.codecargo.io/run/789", url)
 }
 
+// TestPushToApi_ReportsVersion confirms the agent version (#92) rides along on
+// the job push as a top-level field, and is omitted entirely when unset rather
+// than sent empty.
+func TestPushToApi_ReportsVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{name: "set", version: "v1.2.3"},
+		{name: "unset", version: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"job_id": "job-1"}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			c := &SummaryCmd{ApiUrl: srv.URL, Token: "test-token", JobName: "build", Version: tc.version}
+			_, err := c.pushToApi(nil, nil)
+			require.NoError(t, err)
+
+			if tc.version == "" {
+				assert.NotContains(t, got, "version", "version must be omitted when unset")
+				return
+			}
+			assert.Equal(t, tc.version, got["version"])
+			// Version belongs on the request, not nested in the stats summary.
+			if summary, ok := got["summary"].(map[string]any); ok {
+				assert.NotContains(t, summary, "version")
+			}
+		})
+	}
+}
+
 // Blocked events superseded by a later connection_late_allowed for the same
 // (dst_ip, dst_port, protocol) must be dropped so they aren't pushed to the
 // SaaS as denies (#83): the daemon emits the late-allowed record when the

--- a/cmd/summary_test.go
+++ b/cmd/summary_test.go
@@ -829,6 +829,9 @@ func TestPushToApi_ReportsVersion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var got map[string]any
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/api/cargowall/v1/action/job", r.URL.Path)
+				assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 				require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"job_id": "job-1"}`))

--- a/pb/cargowall/v1/cargo_wall_action.pb.go
+++ b/pb/cargowall/v1/cargo_wall_action.pb.go
@@ -25,8 +25,12 @@ const (
 )
 
 type GetCargoWallActionJobRunPolicyRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	JobKey        *string                `protobuf:"bytes,1,opt,name=job_key,json=jobKey,proto3,oneof" json:"job_key,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	JobKey *string                `protobuf:"bytes,1,opt,name=job_key,json=jobKey,proto3,oneof" json:"job_key,omitempty"`
+	// Version of the cargowall agent requesting the policy (e.g. "v1.2.3", or
+	// "develop"/"dev" for unreleased builds). Absent when reported by an agent
+	// predating version reporting.
+	Version       *string `protobuf:"bytes,2,opt,name=version,proto3,oneof" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -64,6 +68,13 @@ func (*GetCargoWallActionJobRunPolicyRequest) Descriptor() ([]byte, []int) {
 func (x *GetCargoWallActionJobRunPolicyRequest) GetJobKey() string {
 	if x != nil && x.JobKey != nil {
 		return *x.JobKey
+	}
+	return ""
+}
+
+func (x *GetCargoWallActionJobRunPolicyRequest) GetVersion() string {
+	if x != nil && x.Version != nil {
+		return *x.Version
 	}
 	return ""
 }
@@ -374,15 +385,19 @@ func (x *CargoWallActionEvent) GetCnameChain() []string {
 type CreateCargoWallActionJobRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// optional - will remove optional annotation in subsequent update
-	JobRunId      *uint64                      `protobuf:"varint,1,opt,name=job_run_id,json=jobRunId,proto3,oneof" json:"job_run_id,omitempty"`
-	JobName       string                       `protobuf:"bytes,2,opt,name=job_name,json=jobName,proto3" json:"job_name,omitempty"`
-	JobKey        string                       `protobuf:"bytes,3,opt,name=job_key,json=jobKey,proto3" json:"job_key,omitempty"`
-	Mode          data.CargoWallMode           `protobuf:"varint,4,opt,name=mode,proto3,enum=grpc.cargowall.v1.CargoWallMode" json:"mode,omitempty"`
-	DefaultAction data.CargoWallActionType     `protobuf:"varint,5,opt,name=default_action,json=defaultAction,proto3,enum=grpc.cargowall.v1.CargoWallActionType" json:"default_action,omitempty"`
-	Summary       *CargoWallActionJobSummary   `protobuf:"bytes,6,opt,name=summary,proto3" json:"summary,omitempty"`
-	StartedAt     *timestamppb.Timestamp       `protobuf:"bytes,7,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
-	CompletedAt   *timestamppb.Timestamp       `protobuf:"bytes,8,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
-	Status        data.CargoWallJobStatus      `protobuf:"varint,9,opt,name=status,proto3,enum=grpc.cargowall.v1.CargoWallJobStatus" json:"status,omitempty"`
+	JobRunId      *uint64                    `protobuf:"varint,1,opt,name=job_run_id,json=jobRunId,proto3,oneof" json:"job_run_id,omitempty"`
+	JobName       string                     `protobuf:"bytes,2,opt,name=job_name,json=jobName,proto3" json:"job_name,omitempty"`
+	JobKey        string                     `protobuf:"bytes,3,opt,name=job_key,json=jobKey,proto3" json:"job_key,omitempty"`
+	Mode          data.CargoWallMode         `protobuf:"varint,4,opt,name=mode,proto3,enum=grpc.cargowall.v1.CargoWallMode" json:"mode,omitempty"`
+	DefaultAction data.CargoWallActionType   `protobuf:"varint,5,opt,name=default_action,json=defaultAction,proto3,enum=grpc.cargowall.v1.CargoWallActionType" json:"default_action,omitempty"`
+	Summary       *CargoWallActionJobSummary `protobuf:"bytes,6,opt,name=summary,proto3" json:"summary,omitempty"`
+	StartedAt     *timestamppb.Timestamp     `protobuf:"bytes,7,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	CompletedAt   *timestamppb.Timestamp     `protobuf:"bytes,8,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
+	Status        data.CargoWallJobStatus    `protobuf:"varint,9,opt,name=status,proto3,enum=grpc.cargowall.v1.CargoWallJobStatus" json:"status,omitempty"`
+	// Version of the cargowall agent that produced this job (e.g. "v1.2.3", or
+	// "develop"/"dev" for unreleased builds). Absent when reported by an agent
+	// predating version reporting.
+	Version       *string                      `protobuf:"bytes,10,opt,name=version,proto3,oneof" json:"version,omitempty"`
 	Steps         []*CreateCargoWallActionStep `protobuf:"bytes,100,rep,name=steps,proto3" json:"steps,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -479,6 +494,13 @@ func (x *CreateCargoWallActionJobRequest) GetStatus() data.CargoWallJobStatus {
 		return x.Status
 	}
 	return data.CargoWallJobStatus(0)
+}
+
+func (x *CreateCargoWallActionJobRequest) GetVersion() string {
+	if x != nil && x.Version != nil {
+		return *x.Version
+	}
+	return ""
 }
 
 func (x *CreateCargoWallActionJobRequest) GetSteps() []*CreateCargoWallActionStep {
@@ -629,11 +651,14 @@ var File_cargo_wall_action_proto protoreflect.FileDescriptor
 
 const file_cargo_wall_action_proto_rawDesc = "" +
 	"\n" +
-	"\x17cargo_wall_action.proto\x12\x11grpc.cargowall.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&data/cargo_wall_action_type_enum.proto\x1a,data/cargo_wall_auto_allowed_type_enum.proto\x1a)data/cargo_wall_event_category_enum.proto\x1a%data/cargo_wall_job_status_enum.proto\x1a\x1fdata/cargo_wall_mode_enum.proto\x1a\x10cargo_wall.proto\"Q\n" +
+	"\x17cargo_wall_action.proto\x12\x11grpc.cargowall.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&data/cargo_wall_action_type_enum.proto\x1a,data/cargo_wall_auto_allowed_type_enum.proto\x1a)data/cargo_wall_event_category_enum.proto\x1a%data/cargo_wall_job_status_enum.proto\x1a\x1fdata/cargo_wall_mode_enum.proto\x1a\x10cargo_wall.proto\"|\n" +
 	"%GetCargoWallActionJobRunPolicyRequest\x12\x1c\n" +
-	"\ajob_key\x18\x01 \x01(\tH\x00R\x06jobKey\x88\x01\x01B\n" +
+	"\ajob_key\x18\x01 \x01(\tH\x00R\x06jobKey\x88\x01\x01\x12\x1d\n" +
+	"\aversion\x18\x02 \x01(\tH\x01R\aversion\x88\x01\x01B\n" +
 	"\n" +
-	"\b_job_key\"\xc3\x02\n" +
+	"\b_job_keyB\n" +
+	"\n" +
+	"\b_version\"\xc3\x02\n" +
 	"\x19CargoWallActionJobSummary\x12+\n" +
 	"\x11total_connections\x18\x01 \x01(\rR\x10totalConnections\x12/\n" +
 	"\x13allowed_connections\x18\x02 \x01(\rR\x12allowedConnections\x12-\n" +
@@ -674,7 +699,7 @@ const file_cargo_wall_action_proto_rawDesc = "" +
 	"\r_matched_ruleB\n" +
 	"\n" +
 	"\b_processB\x14\n" +
-	"\x12_auto_allowed_type\"\xd1\x04\n" +
+	"\x12_auto_allowed_type\"\xfc\x04\n" +
 	"\x1fCreateCargoWallActionJobRequest\x12!\n" +
 	"\n" +
 	"job_run_id\x18\x01 \x01(\x04H\x00R\bjobRunId\x88\x01\x01\x12\x19\n" +
@@ -686,9 +711,13 @@ const file_cargo_wall_action_proto_rawDesc = "" +
 	"\n" +
 	"started_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12=\n" +
 	"\fcompleted_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\vcompletedAt\x12=\n" +
-	"\x06status\x18\t \x01(\x0e2%.grpc.cargowall.v1.CargoWallJobStatusR\x06status\x12B\n" +
+	"\x06status\x18\t \x01(\x0e2%.grpc.cargowall.v1.CargoWallJobStatusR\x06status\x12\x1d\n" +
+	"\aversion\x18\n" +
+	" \x01(\tH\x01R\aversion\x88\x01\x01\x12B\n" +
 	"\x05steps\x18d \x03(\v2,.grpc.cargowall.v1.CreateCargoWallActionStepR\x05stepsB\r\n" +
-	"\v_job_run_id\"\xac\x02\n" +
+	"\v_job_run_idB\n" +
+	"\n" +
+	"\b_version\"\xac\x02\n" +
 	"\x19CreateCargoWallActionStep\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06number\x18\x02 \x01(\x05R\x06number\x12>\n" +

--- a/proto/v1/cargo_wall_action.proto
+++ b/proto/v1/cargo_wall_action.proto
@@ -33,6 +33,10 @@ service CargoWallActionJobService {
 
 message GetCargoWallActionJobRunPolicyRequest {
   optional string job_key = 1;
+  // Version of the cargowall agent requesting the policy (e.g. "v1.2.3", or
+  // "develop"/"dev" for unreleased builds). Absent when reported by an agent
+  // predating version reporting.
+  optional string version = 2;
 }
 
 message CargoWallActionJobSummary {
@@ -83,6 +87,10 @@ message CreateCargoWallActionJobRequest {
   google.protobuf.Timestamp started_at = 7;
   google.protobuf.Timestamp completed_at = 8;
   CargoWallJobStatus status = 9;
+  // Version of the cargowall agent that produced this job (e.g. "v1.2.3", or
+  // "develop"/"dev" for unreleased builds). Absent when reported by an agent
+  // predating version reporting.
+  optional string version = 10;
 
 
   repeated CreateCargoWallActionStep steps = 100;


### PR DESCRIPTION
Closes #92

## Problem

The cargowall agent knows its own build version (`main.version`, injected via `-ldflags -X main.version=$(VERSION)`), but never told the SaaS. Today the version only reaches the OTLP telemetry endpoint as the `service.version` resource attribute — the CodeCargo control API (`/api/cargowall/v1/action/...`) had no version concept at all, so the SaaS couldn't tell which agent version fetched a policy or produced a job.

## Change

Report the version on both SaaS request messages:

- **`GetCargoWallActionJobRunPolicyRequest`** (`optional string version = 2`) — the policy GET at job start, so the version is captured even for runs that never push a summary.
- **`CreateCargoWallActionJobRequest`** (`optional string version = 10`) — the job push at end, so the version lands on the durable job record.

Deliberately **not** on `CargoWallActionJobSummary`: that message is connection-count stats (`total_connections`, `allowed_connections`, …), and the agent version is job/agent metadata, not a stat. It rides as a top-level field on the request instead.

Wiring (the version already existed on the binary — it just wasn't plumbed to these two calls):

- `cargowall.go` — `cli.Summary.Version = version` (previously only `Start` received it, so the `summary` subcommand had no access to the version at all).
- `cmd/summary.go` — new `SummaryCmd.Version` field (`kong:"-"`, mirroring `StartCmd`) → set on the request in `pushToApi`.
- `cmd/api.go` — `fetchPolicyFromAPI` takes `version` and sends it as a query param. The query is now built with `url.Values` (it was string concatenation) so it can carry a second optional param while preserving the existing "omit an unset param entirely rather than send it blank" behavior — the server can still distinguish "not reported" from "reported empty".
- `cmd/start.go` — passes `cmd.Version` through and logs it alongside `job_key`.

No GitHub Action changes needed — the version is baked into the binary. Both fields are `optional`, so an older agent that doesn't send them is fine and the server tolerates their absence.

## Testing

- `cmd/api_test.go` — `fetchPolicyFromAPI` sends `version` (extended the endpoint-assertion server to check it); new `TestFetchPolicyFromAPI_ReportsVersionWithoutJobKey` covers the mixed case (version set, `job_key` absent → version still sent, `job_key` stays omitted).
- `cmd/summary_test.go` — `TestPushToApi_ReportsVersion` (table: set/unset) asserts the version rides top-level on the job push, is omitted when empty, and is **not** nested inside `summary`.
- Mutation-checked: removing each version assignment makes the new tests fail, so they're load-bearing.
- End-to-end: built with `CI_VERSION=v9.9.9-test`, ran the real `summary` binary against a local server — `"version": "v9.9.9-test"` arrived top-level on the wire with the `summary` object empty of it.
- Full `go test ./...` green in the Linux VM; `GOOS=linux go build ./...` / `go vet` / `staticcheck` / `make fmt-check` clean (tests are linux-only). `pb/` regenerated via `make generate-proto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
