### PR TITLE
#119 dns startup window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,9 @@ jobs:
       - name: Verify cloud-provider detection ran
         run: bash scripts/ci/gitlab-ci.sh verify-cloud-detect
 
+      - name: Verify auto-allows precede DNS query filtering
+        run: bash scripts/ci/gitlab-ci.sh verify-startup-order
+
       - name: Validate audit log contains would-deny events
         run: bash scripts/ci/gitlab-ci.sh verify-audit
 

--- a/cmd/container_attribution.go
+++ b/cmd/container_attribution.go
@@ -202,8 +202,9 @@ func (a *containerAttribution) allowLocalNetwork(prefix netip.Prefix) error {
 // startCargoWall: the type exists so boot doesn't thread feature checks,
 // and a nil receiver — attribution off, or step attribution dead — is
 // exactly the case where the hook never adjudicates and no allowance is
-// needed. MUST run after config load (a load replaces the rendered config
-// wholesale) and before UpdateAllowlistTC programs the maps.
+// needed. MUST run before UpdateAllowlistTC programs the maps. (It no longer
+// has to follow the config load: auto-allows are journalled and re-applied
+// across loads, issue #119.)
 func (a *containerAttribution) ensureLoopbackAllowed(configMgr *config.Manager) {
 	if a == nil {
 		return

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -256,16 +256,8 @@ func startCargoWall(cmd *StartCmd, hooks *StartHooks, teardowns *teardownList) e
 	// proxy for future upstream lookups to traverse.
 	var dnsRedirectActive bool
 	if !cmd.DisableDNSTracking {
-		// Install the infrastructure auto-allows BEFORE the proxy below arms
-		// query filtering. Every rule here is derived from local state (CLI
-		// flags, ACTIONS_*/CI_* env, /run/systemd/resolve/resolv.conf, DMI),
-		// so none of it has to wait on the policy fetch — and waiting is what
-		// made the proxy refuse infrastructure hostnames for the length of an
-		// API round trip (issue #119). The config manager replays these onto
-		// whatever policy lands later, so they survive the load that used to
-		// wipe them. Gated on the DNS listeners exactly as the single late
-		// pass was, since that is where the auto-allow set has always been
-		// wired; the rules reach the BPF maps at the UpdateAllowlistTC below.
+		// Infrastructure auto-allows must be installed before the proxy below
+		// arms query filtering (issue #119).
 		populateAutoAllowRules(cmd, configMgr, logger)
 
 		// Get upstream DNS server (defaults to Kubernetes DNS)
@@ -588,8 +580,10 @@ func startCargoWall(cmd *StartCmd, hooks *StartHooks, teardowns *teardownList) e
 		stepTracker, &objs, logger)
 	defer attribution.Close()
 
-	// Userspace half of the loopback carve-out pair — after config load,
-	// before UpdateAllowlistTC programs the maps below.
+	// Userspace half of the loopback carve-out pair — must run before
+	// UpdateAllowlistTC programs the maps below. (Placement relative to the
+	// config load no longer matters: auto-allows are journalled across
+	// loads, issue #119.)
 	attribution.ensureLoopbackAllowed(configMgr)
 
 	// DNS infrastructure, port 53: the proxy's upstream, loopback, and —
@@ -1138,18 +1132,12 @@ func loadCIConfig(ctx context.Context, cmd *StartCmd, configMgr *config.Manager,
 
 	// Priority 1: SaaS API (when api-url + token are set)
 	if cmd.ApiUrl != "" && cmd.Token != "" {
-		// Bootstrap an empty config so EnsureHostnameAllowed can add rules
-		// before the real policy is loaded. Unconditional: every
-		// Ensure*Allowed helper no-ops while cm.config is nil, so skipping
-		// this for a hostname-less api-url would leave lockdown (which also
-		// skips the env/file fallback) with a nil config — a total
-		// blackhole with no DNS or infra allows, contradicting the
-		// documented "CI infrastructure auto-allows remain active".
-		// Non-destructive when populateAutoAllowRules already seeded a base
-		// config: the load replays the recorded auto-allows onto this one.
-		configMgr.LoadConfigFromRules(nil, config.ActionDeny)
 		// The API hostname must be allowed through DNS filtering for the
-		// policy fetch to succeed.
+		// policy fetch to succeed. No bootstrap load ahead of it: the helper
+		// seeds a deny-default config when none exists (issue #119), so
+		// lockdown — which skips the env/file fallback — still ends up with
+		// the documented "CI infrastructure auto-allows remain active"
+		// posture rather than a nil-config blackhole.
 		if u, err := url.Parse(cmd.ApiUrl); err == nil && u.Hostname() != "" {
 			configMgr.EnsureHostnameAllowed(u.Hostname(), []config.Port{config.PortHTTPS}, config.AutoAddedTypeCodeCargoService)
 		}
@@ -1309,16 +1297,12 @@ func handlePolicyFetchFailure(cmd *StartCmd, configMgr *config.Manager, auditLog
 // runs whenever --api-url is set (independent of CI mode) so the SaaS
 // summary push works.
 //
-// Runs before the DNS proxy arms query filtering (issue #119) and therefore
-// before any policy source has been read, so it seeds the empty deny-default
-// config the Ensure*Allowed helpers need — they no-op on a nil config, and
-// the first loader would otherwise be the only thing that could make them
-// stick. No firewall sync here: the rules ride the UpdateAllowlistTC that
-// already runs once the firewall exists, and the manager replays them onto
-// every config loaded in between.
+// Runs before the DNS proxy arms query filtering, and therefore before any
+// policy source has been read: the helpers seed a deny-default config when
+// none is loaded and are journalled onto every later load (issue #119). No
+// firewall sync here either — the rules ride the UpdateAllowlistTC that runs
+// once the firewall exists.
 func populateAutoAllowRules(cmd *StartCmd, configMgr *config.Manager, logger *slog.Logger) {
-	configMgr.EnsureBaseConfig()
-
 	if cmd.AutoAllowCloudMetadata {
 		autoAllowCloudMetadata(configMgr, logger)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -256,6 +256,18 @@ func startCargoWall(cmd *StartCmd, hooks *StartHooks, teardowns *teardownList) e
 	// proxy for future upstream lookups to traverse.
 	var dnsRedirectActive bool
 	if !cmd.DisableDNSTracking {
+		// Install the infrastructure auto-allows BEFORE the proxy below arms
+		// query filtering. Every rule here is derived from local state (CLI
+		// flags, ACTIONS_*/CI_* env, /run/systemd/resolve/resolv.conf, DMI),
+		// so none of it has to wait on the policy fetch — and waiting is what
+		// made the proxy refuse infrastructure hostnames for the length of an
+		// API round trip (issue #119). The config manager replays these onto
+		// whatever policy lands later, so they survive the load that used to
+		// wipe them. Gated on the DNS listeners exactly as the single late
+		// pass was, since that is where the auto-allow set has always been
+		// wired; the rules reach the BPF maps at the UpdateAllowlistTC below.
+		populateAutoAllowRules(cmd, configMgr, logger)
+
 		// Get upstream DNS server (defaults to Kubernetes DNS)
 		upstream := cmd.DNSUpstream
 
@@ -677,19 +689,20 @@ func startCargoWall(cmd *StartCmd, hooks *StartHooks, teardowns *teardownList) e
 			logger.Debug("Updated DNS server with audit logger")
 		}
 
-		applyAutoAllowHelpers(cmd, configMgr, fw, logger)
-
 		// Apply firewall rules to any hostnames tracked before they were
 		// matchable. Two overlapping scenarios funnel here, both fixed by
-		// one pass after auto-allow finishes:
+		// one pass after the config load:
 		//
 		//  1. DNS proxy starts before config load (hooks / prepopulate
 		//     paths) — a hostname like NATS gets resolved while no rule
 		//     exists; the rule arrives later via LoadConfigFromCargoWall.
-		//  2. Auto-allow adds search domains (e.g. `.compute.internal`)
-		//     AFTER the proxy may have seen `bastion.compute.internal`
-		//     as an unmatched full name — stripping now makes the
-		//     short-name `bastion` rule fire.
+		//  2. A policy's own search domains (e.g. `.compute.internal`)
+		//     arrive with that load, AFTER the proxy may have seen
+		//     `bastion.compute.internal` as an unmatched full name —
+		//     stripping now makes the short-name `bastion` rule fire.
+		//     (Auto-allow's suffixes no longer land here: they are
+		//     installed before the proxy starts, and replayed across
+		//     every load — issue #119.)
 		//
 		// Cheap when no tracking has happened yet; idempotent in any case.
 		dnsServer.ApplyRulesToTrackedHostnames()
@@ -1132,6 +1145,8 @@ func loadCIConfig(ctx context.Context, cmd *StartCmd, configMgr *config.Manager,
 		// skips the env/file fallback) with a nil config — a total
 		// blackhole with no DNS or infra allows, contradicting the
 		// documented "CI infrastructure auto-allows remain active".
+		// Non-destructive when populateAutoAllowRules already seeded a base
+		// config: the load replays the recorded auto-allows onto this one.
 		configMgr.LoadConfigFromRules(nil, config.ActionDeny)
 		// The API hostname must be allowed through DNS filtering for the
 		// policy fetch to succeed.
@@ -1289,31 +1304,32 @@ func handlePolicyFetchFailure(cmd *StartCmd, configMgr *config.Manager, auditLog
 	}
 }
 
-// applyAutoAllowHelpers invokes each enabled auto-allow helper and updates
-// the BPF allowlist once at the end. The CodeCargo API allow runs whenever
-// --api-url is set (independent of CI mode) so the SaaS summary push works.
-func applyAutoAllowHelpers(cmd *StartCmd, configMgr *config.Manager, fw firewall.Firewall, logger *slog.Logger) {
-	ran := false
+// populateAutoAllowRules invokes each enabled auto-allow helper, installing
+// the infrastructure allows on the config manager. The CodeCargo API allow
+// runs whenever --api-url is set (independent of CI mode) so the SaaS
+// summary push works.
+//
+// Runs before the DNS proxy arms query filtering (issue #119) and therefore
+// before any policy source has been read, so it seeds the empty deny-default
+// config the Ensure*Allowed helpers need — they no-op on a nil config, and
+// the first loader would otherwise be the only thing that could make them
+// stick. No firewall sync here: the rules ride the UpdateAllowlistTC that
+// already runs once the firewall exists, and the manager replays them onto
+// every config loaded in between.
+func populateAutoAllowRules(cmd *StartCmd, configMgr *config.Manager, logger *slog.Logger) {
+	configMgr.EnsureBaseConfig()
+
 	if cmd.AutoAllowCloudMetadata {
 		autoAllowCloudMetadata(configMgr, logger)
-		ran = true
 	}
 	if cmd.AutoAllowGitHubHosts {
 		autoAllowGitHubHosts(configMgr, logger)
-		ran = true
 	}
 	if cmd.AutoAllowGitlabHosts {
 		autoAllowGitlabHosts(configMgr, logger)
-		ran = true
 	}
 	if cmd.ApiUrl != "" {
 		autoAllowCodeCargoAPI(cmd.ApiUrl, configMgr, logger)
-		ran = true
-	}
-	if ran {
-		if err := fw.UpdateAllowlistTC(configMgr); err != nil {
-			logger.Warn("Failed to update allowlist with auto-allow rules", "error", err)
-		}
 	}
 }
 

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -31,7 +31,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -495,53 +494,70 @@ func TestAutoAllowGitlabHosts_ServiceHostsEnvOverridesDefaults(t *testing.T) {
 	require.NotContains(t, got, "gitlab.com", "default hosts should be replaced when env override is set")
 }
 
-// applyAutoAllowHelpers must NOT touch the firewall when no helper would
-// run — otherwise it'd push an unchanged allowlist on every call and waste
-// BPF map work for standalone users with no auto-allow flags set.
-func TestApplyAutoAllowHelpers_NoFlagsNoUpdate(t *testing.T) {
+// populateAutoAllowRules runs before any policy source has been read, so it
+// must seed the deny-default base config itself — every Ensure*Allowed
+// helper no-ops on a nil config, and without the seed the DNS proxy would
+// arm query filtering against a manager that cannot hold a rule (#119).
+func TestPopulateAutoAllowRules_NoFlagsSeedsBaseConfig(t *testing.T) {
 	cm := config.NewConfigManager()
-	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
-
-	// NewMockFirewall(t) fails the test on any unexpected call, so the
-	// absence of an EXPECT() asserts UpdateAllowlistTC is never invoked.
-	fw := firewall.NewMockFirewall(t)
 
 	cmd := &StartCmd{} // every flag false, no ApiUrl
-	applyAutoAllowHelpers(cmd, cm, fw, quietLogger())
+	populateAutoAllowRules(cmd, cm, quietLogger())
+
+	require.Equal(t, config.ActionDeny, cm.GetDefaultAction())
+	require.Empty(t, cm.GetResolvedRules(), "no helper enabled means no rules")
+
+	// The seeded config is writable — the property the seed exists for.
+	cm.EnsureHostnameAllowed("example.com", []config.Port{config.PortHTTPS}, config.AutoAddedTypeGitHubService)
+	require.True(t, cm.MatchHostnameRule("example.com").HasAllow())
 }
 
-// When at least one helper runs, the dispatcher must call UpdateAllowlistTC
-// exactly once at the end (not once per helper).
-func TestApplyAutoAllowHelpers_AnyFlagTriggersSingleUpdate(t *testing.T) {
+// The infrastructure allows must be queryable on a manager that has never
+// loaded a policy — that is the whole point of running this pass before the
+// DNS proxy arms filtering (#119).
+func TestPopulateAutoAllowRules_MatchableBeforeAnyPolicyLoad(t *testing.T) {
+	cm := config.NewConfigManager()
+
+	cmd := &StartCmd{ApiUrl: "https://app.codecargo.com"}
+	populateAutoAllowRules(cmd, cm, quietLogger())
+
+	require.True(t, cm.MatchHostnameRule("app.codecargo.com").HasAllow(),
+		"the SaaS API hostname must be allowed before the policy fetch it carries")
+}
+
+// ApiUrl alone (no CI flags) is enough, because the CodeCargo API allow runs
+// whenever an api-url is set.
+func TestPopulateAutoAllowRules_ApiUrlAloneAddsHostname(t *testing.T) {
+	cm := config.NewConfigManager()
+
+	cmd := &StartCmd{ApiUrl: "https://api.codecargo.com"}
+	populateAutoAllowRules(cmd, cm, quietLogger())
+
+	got := hostnameRulesFor(t, cm, config.AutoAddedTypeCodeCargoService)
+	require.Contains(t, got, "api.codecargo.com")
+}
+
+// The pass runs before the policy fetch, so the policy that lands afterwards
+// must not wipe what it installed — the failure this whole reordering exists
+// to prevent (#119).
+func TestPopulateAutoAllowRules_SurvivesLaterPolicyLoad(t *testing.T) {
 	t.Setenv("CI_SERVER_URL", "")
 	t.Setenv("CI_REGISTRY", "")
 	t.Setenv("CI_API_V4_URL", "")
 
 	cm := config.NewConfigManager()
-	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
+	cmd := &StartCmd{AutoAllowGitlabHosts: true, ApiUrl: "https://app.codecargo.com"}
+	populateAutoAllowRules(cmd, cm, quietLogger())
 
-	fw := firewall.NewMockFirewall(t)
-	fw.EXPECT().UpdateAllowlistTC(mock.Anything).Return(nil).Once()
+	// A policy naming none of the auto-allowed hostnames.
+	require.NoError(t, cm.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "github.com", Action: config.ActionAllow},
+	}, config.ActionDeny))
 
-	cmd := &StartCmd{AutoAllowGitlabHosts: true}
-	applyAutoAllowHelpers(cmd, cm, fw, quietLogger())
-}
-
-// ApiUrl alone (no CI flags) is enough to trigger the dispatcher because the
-// CodeCargo API allow runs whenever an api-url is set.
-func TestApplyAutoAllowHelpers_ApiUrlAloneTriggersUpdate(t *testing.T) {
-	cm := config.NewConfigManager()
-	require.NoError(t, cm.LoadConfigFromRules(nil, config.ActionDeny))
-
-	fw := firewall.NewMockFirewall(t)
-	fw.EXPECT().UpdateAllowlistTC(mock.Anything).Return(nil).Once()
-
-	cmd := &StartCmd{ApiUrl: "https://api.codecargo.com"}
-	applyAutoAllowHelpers(cmd, cm, fw, quietLogger())
-
-	// And the API hostname should be in the resolved rules.
-	got := hostnameRulesFor(t, cm, config.AutoAddedTypeCodeCargoService)
-	require.Contains(t, got, "api.codecargo.com")
+	require.True(t, cm.MatchHostnameRule("app.codecargo.com").HasAllow(),
+		"the SaaS API hostname must survive the policy load")
+	require.Contains(t, hostnameRulesFor(t, cm, config.AutoAddedTypeGitLabService), "gitlab.com")
+	require.True(t, cm.MatchHostnameRule("github.com").HasAllow(), "policy rules still load")
 }
 
 // emptyDMI / dmiWithVendor / dmiWithChassisTag isolate cloud-detection tests

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -494,11 +494,9 @@ func TestAutoAllowGitlabHosts_ServiceHostsEnvOverridesDefaults(t *testing.T) {
 	require.NotContains(t, got, "gitlab.com", "default hosts should be replaced when env override is set")
 }
 
-// populateAutoAllowRules runs before any policy source has been read, so it
-// must seed the deny-default base config itself — every Ensure*Allowed
-// helper no-ops on a nil config, and without the seed the DNS proxy would
-// arm query filtering against a manager that cannot hold a rule (#119).
-func TestPopulateAutoAllowRules_NoFlagsSeedsBaseConfig(t *testing.T) {
+// No flags means no helpers, and therefore no rules and no config — a
+// standalone run must not acquire a policy it never asked for.
+func TestPopulateAutoAllowRules_NoFlagsInstallsNothing(t *testing.T) {
 	cm := config.NewConfigManager()
 
 	cmd := &StartCmd{} // every flag false, no ApiUrl
@@ -506,10 +504,6 @@ func TestPopulateAutoAllowRules_NoFlagsSeedsBaseConfig(t *testing.T) {
 
 	require.Equal(t, config.ActionDeny, cm.GetDefaultAction())
 	require.Empty(t, cm.GetResolvedRules(), "no helper enabled means no rules")
-
-	// The seeded config is writable — the property the seed exists for.
-	cm.EnsureHostnameAllowed("example.com", []config.Port{config.PortHTTPS}, config.AutoAddedTypeGitHubService)
-	require.True(t, cm.MatchHostnameRule("example.com").HasAllow())
 }
 
 // The infrastructure allows must be queryable on a manager that has never
@@ -1139,11 +1133,11 @@ func TestStartCargoWall_FatalErrorWritesFailureSentinel(t *testing.T) {
 	assert.Contains(t, string(data), "cargowall startup failed")
 }
 
-// A hostname-less --api-url must still bootstrap the deny-all config:
-// lockdown skips the env/file fallback, so without the bootstrap the manager
-// would hold a nil config where every Ensure*Allowed no-ops — a blackhole
-// with no DNS or CI-infra allows, contradicting the lockdown contract.
-func TestLoadCIConfig_LockdownBootstrapsWithHostnamelessApiUrl(t *testing.T) {
+// Lockdown skips the env/file fallback, so a hostname-less --api-url leaves
+// the manager with no config at all — and the CI infrastructure auto-allows
+// that run afterwards must still stick, or lockdown is a blackhole with no
+// DNS or infra allows rather than the documented deny-all posture.
+func TestLoadCIConfig_LockdownKeepsInfraAllowsWithHostnamelessApiUrl(t *testing.T) {
 	setFastPolicyRetries(t)
 	redirectStateFiles(t)
 
@@ -1160,12 +1154,13 @@ func TestLoadCIConfig_LockdownBootstrapsWithHostnamelessApiUrl(t *testing.T) {
 
 	require.True(t, cmd.policyLockdown, "an unsupported scheme is a transport failure")
 	assert.Equal(t, config.ActionDeny, cm.GetDefaultAction())
-	// The DNS/infra auto-allows now run in startCargoWall AFTER config load
-	// (gated on the listeners, not CI mode), so probe the property directly:
-	// Ensure*Allowed no-ops on a nil config, and a rule landing proves the
-	// lockdown bootstrap left the manager writable for those later calls.
+	// The DNS/infra auto-allows are wired to the listeners, not to CI mode,
+	// so probe the property directly: a rule landing proves lockdown left the
+	// manager writable for them (the helpers seed a deny-default config when
+	// the fetch never produced one — issue #119).
 	cm.EnsureDNSAllowed([]string{"127.0.0.1"})
-	assert.NotEmpty(t, cm.GetResolvedRules(), "lockdown must still accept the DNS/infra allows added after load")
+	assert.NotEmpty(t, cm.GetResolvedRules(), "lockdown must still accept the DNS/infra allows")
+	assert.Equal(t, config.ActionDeny, cm.GetDefaultAction(), "seeding must not soften the lockdown posture")
 }
 
 // The pid stamped into a sentinel identifies its run exactly — a leftover

--- a/pkg/config/autoallow.go
+++ b/pkg/config/autoallow.go
@@ -21,23 +21,23 @@ import (
 	"slices"
 )
 
-// The auto-allow replay layer (issue #119).
+// The auto-allow journal (issue #119).
 //
 // Rules added by the Ensure*Allowed helpers and AddSearchDomains are not
-// policy — they are the infrastructure a run needs to function at all: the
-// cloud metadata endpoint, the Azure wireserver, the CI control plane, the
-// SaaS API, loopback. Every loader replaces cm.config wholesale, so those
-// rules used to survive only by being installed AFTER the last load. That
-// is why the auto-allow helpers ran behind the policy fetch — and why the
-// DNS proxy armed query filtering against an empty ruleset for the length
-// of an API round trip, refusing infrastructure hostnames (issue #119).
+// policy — they are the infrastructure a run needs to function at all: cloud
+// metadata, the Azure wireserver, the CI control plane, the SaaS API,
+// loopback. Every loader replaces cm.config wholesale, so before this layer
+// they survived only by being installed after the last load, which is why
+// they ran behind the policy fetch — leaving the DNS proxy filtering against
+// an empty ruleset for the length of an API round trip.
 //
-// Recording each call and replaying it after every load inverts that: the
-// helpers can run before the proxy starts, and a later policy load
-// re-applies them instead of wiping them. Replay drives the same locked
-// cores as the original call, in the original order, so a loaded policy
-// that denies an auto-allowed network still vetoes it exactly as it did
-// when the helpers ran last.
+// The contract: record each call's INPUT, re-run the same locked cores after
+// every load. Re-running the cores (rather than re-appending the rules they
+// produced) is what keeps the verdict identical to the old auto-allow-runs-
+// last ordering — a CIDR auto-allow is still vetoed by a loaded deny that
+// covers it, and a hostname auto-allow still wins over a policy deny for the
+// same exact name (#121). This layer moves WHEN rules are installed, never
+// WHICH rule wins.
 
 // autoAllowKind distinguishes the three shapes of auto-add the helpers
 // record. Kept internal: nothing outside this package needs to enumerate
@@ -51,10 +51,6 @@ const (
 )
 
 // autoAllowEntry is one recorded Ensure*Allowed / AddSearchDomains call.
-// It stores the helper's INPUT rather than the rule it produced, so a
-// replay re-runs the deny-veto and dedup checks against whatever ruleset is
-// loaded at that moment instead of resurrecting a decision made against an
-// older one.
 type autoAllowEntry struct {
 	kind     autoAllowKind
 	values   []string // CIDRs/IPs, one hostname, or normalized search domains
@@ -69,12 +65,10 @@ func (e autoAllowEntry) equal(other autoAllowEntry) bool {
 		slices.Equal(e.ports, other.ports)
 }
 
-// recordAutoAllowLocked appends an entry to the replay layer, ignoring an
-// exact repeat: call sites that predate this layer still invoke the helpers
-// more than once (loadCIConfig allows the API hostname so its own fetch can
-// resolve, and the auto-allow pass names it again), and each repeat would
-// otherwise grow the replay list and re-log on every load. Clones the
-// caller's slices — the layer outlives the call. Caller holds cm.mu.
+// recordAutoAllowLocked journals an entry, ignoring an exact repeat — some
+// call sites name the same hostname twice, and each repeat would otherwise
+// grow the list replayed on every load. Clones the caller's slices: the
+// journal outlives the call. Caller holds cm.mu.
 func (cm *Manager) recordAutoAllowLocked(entry autoAllowEntry) {
 	entry.values = slices.Clone(entry.values)
 	entry.ports = slices.Clone(entry.ports)
@@ -86,13 +80,20 @@ func (cm *Manager) recordAutoAllowLocked(entry autoAllowEntry) {
 	cm.autoAllows = append(cm.autoAllows, entry)
 }
 
-// replayAutoAllowsLocked re-applies every recorded auto-add onto the config
+// replayAutoAllowsLocked re-applies every journalled auto-add onto the config
 // a loader just installed. applyLoadedConfig calls it after
-// resolveRulesLocked so the cores see the new resolvedRules — their dedup
-// and deny-veto checks then run against the freshly loaded policy, which is
-// the same precedence the helpers had when they ran after the load.
-// Caller holds cm.mu.
+// resolveRulesLocked, so the cores' dedup and deny-veto checks see the new
+// ruleset. Caller holds cm.mu.
+//
+// The cores run in replay mode: an auto-allow is announced in the ops log
+// once, where it is installed. Re-announcing every rule on every load would
+// misdate the install and — since the CI gate for #119 keys on that
+// announcement preceding the DNS proxy arming — would also make a replay
+// indistinguishable from a late install. One summary line covers the pass.
 func (cm *Manager) replayAutoAllowsLocked() {
+	if len(cm.autoAllows) == 0 {
+		return
+	}
 	for _, entry := range cm.autoAllows {
 		switch entry.kind {
 		case autoAllowCIDR:
@@ -107,30 +108,15 @@ func (cm *Manager) replayAutoAllowsLocked() {
 			cm.addSearchDomainsLocked(entry.values)
 		}
 	}
+	slog.Debug("Re-applied journalled auto-allows onto the loaded config", "count", len(cm.autoAllows))
 }
 
-// EnsureBaseConfig installs an empty deny-default config when no loader has
-// run yet, so the Ensure*Allowed helpers — which no-op on a nil config —
-// can install the infrastructure allows before the first policy source is
-// read (issue #119). Idempotent: a config from any loader is left alone.
-//
-// Deny-default matches every other pre-policy posture in the daemon
-// (GetDefaultAction already reports deny for a nil config), so this changes
-// what is ALLOWED during startup, never what is denied.
-func (cm *Manager) EnsureBaseConfig() {
-	cm.mu.Lock()
-	defer cm.mu.Unlock()
-
-	if cm.config != nil {
-		return
+// seedBaseConfigLocked gives an auto-allow somewhere to land when no loader
+// has run yet. Deny-default is already what GetDefaultAction reports for a
+// nil config, so seeding changes what is ALLOWED before a policy arrives,
+// never what is denied. Caller holds cm.mu.
+func (cm *Manager) seedBaseConfigLocked() {
+	if cm.config == nil {
+		cm.config = &FirewallConfig{DefaultAction: ActionDeny}
 	}
-	cm.config = &FirewallConfig{DefaultAction: ActionDeny}
-	// An empty ruleset resolves to an empty resolvedRules; the replay below
-	// is what actually populates it when helpers already recorded entries
-	// against the nil config.
-	if err := cm.resolveRulesLocked(); err != nil {
-		slog.Error("Failed to resolve base config", "error", err)
-		return
-	}
-	cm.replayAutoAllowsLocked()
 }

--- a/pkg/config/autoallow.go
+++ b/pkg/config/autoallow.go
@@ -1,0 +1,136 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package config
+
+import (
+	"log/slog"
+	"slices"
+)
+
+// The auto-allow replay layer (issue #119).
+//
+// Rules added by the Ensure*Allowed helpers and AddSearchDomains are not
+// policy — they are the infrastructure a run needs to function at all: the
+// cloud metadata endpoint, the Azure wireserver, the CI control plane, the
+// SaaS API, loopback. Every loader replaces cm.config wholesale, so those
+// rules used to survive only by being installed AFTER the last load. That
+// is why the auto-allow helpers ran behind the policy fetch — and why the
+// DNS proxy armed query filtering against an empty ruleset for the length
+// of an API round trip, refusing infrastructure hostnames (issue #119).
+//
+// Recording each call and replaying it after every load inverts that: the
+// helpers can run before the proxy starts, and a later policy load
+// re-applies them instead of wiping them. Replay drives the same locked
+// cores as the original call, in the original order, so a loaded policy
+// that denies an auto-allowed network still vetoes it exactly as it did
+// when the helpers ran last.
+
+// autoAllowKind distinguishes the three shapes of auto-add the helpers
+// record. Kept internal: nothing outside this package needs to enumerate
+// them, and the recorded form is an implementation detail of replay.
+type autoAllowKind uint8
+
+const (
+	autoAllowCIDR autoAllowKind = iota
+	autoAllowHostname
+	autoAllowSearchDomain
+)
+
+// autoAllowEntry is one recorded Ensure*Allowed / AddSearchDomains call.
+// It stores the helper's INPUT rather than the rule it produced, so a
+// replay re-runs the deny-veto and dedup checks against whatever ruleset is
+// loaded at that moment instead of resurrecting a decision made against an
+// older one.
+type autoAllowEntry struct {
+	kind     autoAllowKind
+	values   []string // CIDRs/IPs, one hostname, or normalized search domains
+	ports    []Port
+	autoType AutoAddedType
+}
+
+func (e autoAllowEntry) equal(other autoAllowEntry) bool {
+	return e.kind == other.kind &&
+		e.autoType == other.autoType &&
+		slices.Equal(e.values, other.values) &&
+		slices.Equal(e.ports, other.ports)
+}
+
+// recordAutoAllowLocked appends an entry to the replay layer, ignoring an
+// exact repeat: call sites that predate this layer still invoke the helpers
+// more than once (loadCIConfig allows the API hostname so its own fetch can
+// resolve, and the auto-allow pass names it again), and each repeat would
+// otherwise grow the replay list and re-log on every load. Clones the
+// caller's slices — the layer outlives the call. Caller holds cm.mu.
+func (cm *Manager) recordAutoAllowLocked(entry autoAllowEntry) {
+	entry.values = slices.Clone(entry.values)
+	entry.ports = slices.Clone(entry.ports)
+	for _, existing := range cm.autoAllows {
+		if existing.equal(entry) {
+			return
+		}
+	}
+	cm.autoAllows = append(cm.autoAllows, entry)
+}
+
+// replayAutoAllowsLocked re-applies every recorded auto-add onto the config
+// a loader just installed. applyLoadedConfig calls it after
+// resolveRulesLocked so the cores see the new resolvedRules — their dedup
+// and deny-veto checks then run against the freshly loaded policy, which is
+// the same precedence the helpers had when they ran after the load.
+// Caller holds cm.mu.
+func (cm *Manager) replayAutoAllowsLocked() {
+	for _, entry := range cm.autoAllows {
+		switch entry.kind {
+		case autoAllowCIDR:
+			cm.ensureAllowedLocked(entry.values, entry.ports, entry.autoType, true)
+		case autoAllowHostname:
+			// One hostname per entry; a malformed record would mean a bug in
+			// EnsureHostnameAllowed, so skip rather than index blindly.
+			if len(entry.values) == 1 {
+				cm.ensureHostnameAllowedLocked(entry.values[0], entry.ports, entry.autoType, true)
+			}
+		case autoAllowSearchDomain:
+			cm.addSearchDomainsLocked(entry.values)
+		}
+	}
+}
+
+// EnsureBaseConfig installs an empty deny-default config when no loader has
+// run yet, so the Ensure*Allowed helpers — which no-op on a nil config —
+// can install the infrastructure allows before the first policy source is
+// read (issue #119). Idempotent: a config from any loader is left alone.
+//
+// Deny-default matches every other pre-policy posture in the daemon
+// (GetDefaultAction already reports deny for a nil config), so this changes
+// what is ALLOWED during startup, never what is denied.
+func (cm *Manager) EnsureBaseConfig() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	if cm.config != nil {
+		return
+	}
+	cm.config = &FirewallConfig{DefaultAction: ActionDeny}
+	// An empty ruleset resolves to an empty resolvedRules; the replay below
+	// is what actually populates it when helpers already recorded entries
+	// against the nil config.
+	if err := cm.resolveRulesLocked(); err != nil {
+		slog.Error("Failed to resolve base config", "error", err)
+		return
+	}
+	cm.replayAutoAllowsLocked()
+}

--- a/pkg/config/autoallow_test.go
+++ b/pkg/config/autoallow_test.go
@@ -1,0 +1,169 @@
+//   Copyright 2026 BoxBuild Inc DBA CodeCargo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build linux
+
+package config
+
+import (
+	"log/slog"
+	"slices"
+	"testing"
+)
+
+// countRules returns how many resolved rules carry the given auto-added
+// type, so a replay that duplicated entries is visible rather than hidden
+// behind a "does it match" check.
+func countRules(cm *Manager, autoType AutoAddedType) int {
+	n := 0
+	for _, r := range cm.GetResolvedRules() {
+		if r.AutoAddedType == autoType {
+			n++
+		}
+	}
+	return n
+}
+
+// A config load replaces cm.config wholesale. Every auto-added
+// infrastructure allow must survive it — the auto-allow pass now runs
+// before the policy fetch, so a wipe would leave the DNS proxy refusing
+// infrastructure hostnames for the length of that fetch (issue #119).
+func TestAutoAllowReplay_SurvivesConfigLoad(t *testing.T) {
+	cm := NewConfigManager()
+	cm.EnsureBaseConfig()
+
+	cm.EnsureHostnameAllowed("blob.core.windows.net", []Port{PortHTTPS}, AutoAddedTypeAzureInfrastructure)
+	cm.EnsureInfraAllowed([]string{"168.63.129.16"}, []Port{PortHTTP}, AutoAddedTypeAzureInfrastructure)
+	cm.AddSearchDomains([]string{".internal.cloudapp.net"}, slog.Default())
+
+	// The policy that lands afterwards names none of them.
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeHostname, Value: "github.com", Action: ActionAllow},
+	}, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+
+	v := cm.MatchHostnameRule("productionresultssa16.blob.core.windows.net")
+	if !v.HasAllow() {
+		t.Errorf("after load, MatchHostnameRule(subdomain) = %+v, want allow", v)
+	}
+	if v.AllowRule != "blob.core.windows.net" {
+		t.Errorf("after load, AllowRule = %q, want blob.core.windows.net", v.AllowRule)
+	}
+	if !slices.Contains(cm.GetSearchDomains(), ".internal.cloudapp.net") {
+		t.Errorf("after load, GetSearchDomains() = %v, want the auto-added suffix", cm.GetSearchDomains())
+	}
+	if got := countRules(cm, AutoAddedTypeAzureInfrastructure); got != 2 {
+		t.Errorf("after load, azure_infrastructure rules = %d, want 2 (hostname + CIDR, no duplicates)", got)
+	}
+	if !cm.MatchHostnameRule("github.com").HasAllow() {
+		t.Errorf("the loaded policy's own rules must still apply")
+	}
+}
+
+// Replay runs the same suppression checks as the original call against the
+// NEWLY loaded ruleset, so an operator deny arriving with the policy still
+// vetoes an infra auto-allow — the precedence the old "auto-allow always
+// runs last" ordering gave for free.
+func TestAutoAllowReplay_LoadedDenyVetoesInfraAllow(t *testing.T) {
+	cm := NewConfigManager()
+	cm.EnsureBaseConfig()
+	cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{PortHTTP}, AutoAddedTypeCloudMetadata)
+
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeCIDR, Value: "169.254.0.0/16", Action: ActionDeny},
+	}, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+
+	if got := countRules(cm, AutoAddedTypeCloudMetadata); got != 0 {
+		t.Errorf("cloud_metadata rules after a covering deny = %d, want 0 (vetoed)", got)
+	}
+}
+
+// Helpers called before any loader has run record their input even though
+// the application no-ops on a nil config, so the first load installs them.
+// This is what lets the auto-allow pass precede the policy fetch.
+func TestAutoAllowReplay_RecordedBeforeAnyConfigExists(t *testing.T) {
+	cm := NewConfigManager()
+
+	cm.EnsureHostnameAllowed("github.com", []Port{PortHTTPS}, AutoAddedTypeGitHubService)
+	if len(cm.GetResolvedRules()) != 0 {
+		t.Fatalf("nil config must stay ruleless, got %d rules", len(cm.GetResolvedRules()))
+	}
+
+	if err := cm.LoadConfigFromRules(nil, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	if !cm.MatchHostnameRule("github.com").HasAllow() {
+		t.Errorf("the recorded allow must land on the first loaded config")
+	}
+}
+
+// Repeated identical calls (call sites that predate the replay layer still
+// name the same hostname twice) must not stack up entries that re-log and
+// re-apply on every load.
+func TestAutoAllowReplay_DedupsIdenticalCalls(t *testing.T) {
+	cm := NewConfigManager()
+	cm.EnsureBaseConfig()
+
+	for range 3 {
+		cm.EnsureHostnameAllowed("app.codecargo.com", []Port{PortHTTPS}, AutoAddedTypeCodeCargoService)
+	}
+	if got := len(cm.autoAllows); got != 1 {
+		t.Errorf("recorded auto-allows = %d, want 1", got)
+	}
+
+	if err := cm.LoadConfigFromRules(nil, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	if got := countRules(cm, AutoAddedTypeCodeCargoService); got != 1 {
+		t.Errorf("codecargo_service rules after load = %d, want 1", got)
+	}
+}
+
+// EnsureBaseConfig only fills a vacuum: an already-loaded policy must not be
+// replaced by the deny-default stub.
+func TestEnsureBaseConfig_LeavesLoadedConfigAlone(t *testing.T) {
+	cm := NewConfigManager()
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeHostname, Value: "github.com", Action: ActionAllow},
+	}, ActionAllow); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+
+	cm.EnsureBaseConfig()
+
+	if got := cm.GetDefaultAction(); got != ActionAllow {
+		t.Errorf("GetDefaultAction() = %q, want %q (loaded config untouched)", got, ActionAllow)
+	}
+	if !cm.MatchHostnameRule("github.com").HasAllow() {
+		t.Errorf("the loaded rule must survive EnsureBaseConfig")
+	}
+}
+
+// A fresh manager has no config at all, so the base config must both exist
+// and be deny-default — the same posture GetDefaultAction reports for nil.
+func TestEnsureBaseConfig_SeedsDenyDefault(t *testing.T) {
+	cm := NewConfigManager()
+	cm.EnsureBaseConfig()
+
+	if got := cm.GetDefaultAction(); got != ActionDeny {
+		t.Errorf("GetDefaultAction() = %q, want %q", got, ActionDeny)
+	}
+	cm.EnsureHostnameAllowed("github.com", []Port{PortHTTPS}, AutoAddedTypeGitHubService)
+	if !cm.MatchHostnameRule("github.com").HasAllow() {
+		t.Errorf("the seeded config must accept auto-allow rules")
+	}
+}

--- a/pkg/config/autoallow_test.go
+++ b/pkg/config/autoallow_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -41,7 +42,6 @@ func countRules(cm *Manager, autoType AutoAddedType) int {
 // infrastructure hostnames for the length of that fetch (issue #119).
 func TestAutoAllowReplay_SurvivesConfigLoad(t *testing.T) {
 	cm := NewConfigManager()
-	cm.EnsureBaseConfig()
 
 	cm.EnsureHostnameAllowed("blob.core.windows.net", []Port{PortHTTPS}, AutoAddedTypeAzureInfrastructure)
 	cm.EnsureInfraAllowed([]string{"168.63.129.16"}, []Port{PortHTTP}, AutoAddedTypeAzureInfrastructure)
@@ -78,7 +78,6 @@ func TestAutoAllowReplay_SurvivesConfigLoad(t *testing.T) {
 // runs last" ordering gave for free.
 func TestAutoAllowReplay_LoadedDenyVetoesInfraAllow(t *testing.T) {
 	cm := NewConfigManager()
-	cm.EnsureBaseConfig()
 	cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{PortHTTP}, AutoAddedTypeCloudMetadata)
 
 	if err := cm.LoadConfigFromRules([]Rule{
@@ -92,22 +91,59 @@ func TestAutoAllowReplay_LoadedDenyVetoesInfraAllow(t *testing.T) {
 	}
 }
 
-// Helpers called before any loader has run record their input even though
-// the application no-ops on a nil config, so the first load installs them.
-// This is what lets the auto-allow pass precede the policy fetch.
-func TestAutoAllowReplay_RecordedBeforeAnyConfigExists(t *testing.T) {
+// Hostname auto-allows have no deny-veto: an allow for a name the policy
+// denies is appended anyway and wins on exact-match-last. That asymmetry
+// with the CIDR path predates the replay layer, and this pins the property
+// that matters here — the reorder must not CHANGE the verdict. Both
+// orderings (helpers after the load, as before #119; helpers before it,
+// replayed) must agree, whatever that verdict is.
+func TestAutoAllowReplay_HostnamePrecedenceUnchangedByOrdering(t *testing.T) {
+	const host = "blob.core.windows.net"
+	policy := []Rule{{Type: RuleTypeHostname, Value: host, Action: ActionDeny}}
+
+	// Pre-#119 ordering: policy first, auto-allow after.
+	afterLoad := NewConfigManager()
+	if err := afterLoad.LoadConfigFromRules(policy, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+	afterLoad.EnsureHostnameAllowed(host, []Port{PortHTTPS}, AutoAddedTypeAzureInfrastructure)
+
+	// Post-#119 ordering: auto-allow first, replayed by the load.
+	beforeLoad := NewConfigManager()
+	beforeLoad.EnsureHostnameAllowed(host, []Port{PortHTTPS}, AutoAddedTypeAzureInfrastructure)
+	if err := beforeLoad.LoadConfigFromRules(policy, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+
+	got, want := beforeLoad.MatchHostnameRule(host), afterLoad.MatchHostnameRule(host)
+	if got.HasAllow() != want.HasAllow() || got.HasDeny() != want.HasDeny() ||
+		got.AllowRule != want.AllowRule || got.DenyRule != want.DenyRule {
+		t.Errorf("verdict differs by ordering:\n  replayed    = %+v\n  after-load  = %+v", got, want)
+	}
+	// Documenting the shared verdict rather than asserting it is right: the
+	// auto-allow wins. Whether it should is issue #121.
+	if !got.HasAllow() {
+		t.Errorf("expected the documented (allow-wins) verdict, got %+v", got)
+	}
+}
+
+// A helper called before any loader has run is matchable immediately — the
+// property the whole reorder rests on, since the DNS proxy arms query
+// filtering before the first policy source is read.
+func TestAutoAllowReplay_MatchableOnAFreshManager(t *testing.T) {
 	cm := NewConfigManager()
 
 	cm.EnsureHostnameAllowed("github.com", []Port{PortHTTPS}, AutoAddedTypeGitHubService)
-	if len(cm.GetResolvedRules()) != 0 {
-		t.Fatalf("nil config must stay ruleless, got %d rules", len(cm.GetResolvedRules()))
+	if !cm.MatchHostnameRule("api.github.com").HasAllow() {
+		t.Fatalf("auto-allow must be matchable with no config loaded, got %d rules", len(cm.GetResolvedRules()))
 	}
 
+	// And it survives the load that arrives later.
 	if err := cm.LoadConfigFromRules(nil, ActionDeny); err != nil {
 		t.Fatalf("LoadConfigFromRules() error = %v", err)
 	}
-	if !cm.MatchHostnameRule("github.com").HasAllow() {
-		t.Errorf("the recorded allow must land on the first loaded config")
+	if !cm.MatchHostnameRule("api.github.com").HasAllow() {
+		t.Errorf("the journalled allow must survive the first loaded config")
 	}
 }
 
@@ -116,7 +152,6 @@ func TestAutoAllowReplay_RecordedBeforeAnyConfigExists(t *testing.T) {
 // re-apply on every load.
 func TestAutoAllowReplay_DedupsIdenticalCalls(t *testing.T) {
 	cm := NewConfigManager()
-	cm.EnsureBaseConfig()
 
 	for range 3 {
 		cm.EnsureHostnameAllowed("app.codecargo.com", []Port{PortHTTPS}, AutoAddedTypeCodeCargoService)
@@ -133,9 +168,60 @@ func TestAutoAllowReplay_DedupsIdenticalCalls(t *testing.T) {
 	}
 }
 
-// EnsureBaseConfig only fills a vacuum: an already-loaded policy must not be
-// replaced by the deny-default stub.
-func TestEnsureBaseConfig_LeavesLoadedConfigAlone(t *testing.T) {
+// The ops log announces an auto-allow once, where it is installed. A replay
+// must stay silent: re-announcing the same rules on every load misdates the
+// install, and the #119 CI gate — which asserts the last announcement
+// precedes the DNS proxy arming — cannot tell a replay from a late install.
+func TestAutoAllowReplay_DoesNotReAnnounce(t *testing.T) {
+	var captured []string
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&captureWriter{out: &captured},
+		&slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	cm := NewConfigManager()
+	cm.EnsureHostnameAllowed("gitlab.com", []Port{PortHTTPS}, AutoAddedTypeGitLabService)
+	cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{PortHTTP}, AutoAddedTypeCloudMetadata)
+
+	if got := countLines(captured, "Auto-added infrastructure hostname allow rule"); got != 1 {
+		t.Fatalf("hostname install announcements = %d, want 1", got)
+	}
+	if got := countLines(captured, "Auto-added allow rule"); got != 1 {
+		t.Fatalf("CIDR install announcements = %d, want 1", got)
+	}
+
+	captured = nil
+	if err := cm.LoadConfigFromRules([]Rule{
+		{Type: RuleTypeHostname, Value: "github.com", Action: ActionAllow},
+	}, ActionDeny); err != nil {
+		t.Fatalf("LoadConfigFromRules() error = %v", err)
+	}
+
+	if got := countLines(captured, "Auto-added"); got != 0 {
+		t.Errorf("replay re-announced %d install lines, want 0: %v", got, captured)
+	}
+	// Silent, but not absent from the log entirely — and the rules landed.
+	if got := countLines(captured, "Re-applied journalled auto-allows"); got != 1 {
+		t.Errorf("replay summary lines = %d, want 1", got)
+	}
+	if !cm.MatchHostnameRule("gitlab.com").HasAllow() {
+		t.Errorf("a silent replay must still install the rules")
+	}
+}
+
+func countLines(lines []string, substr string) int {
+	n := 0
+	for _, line := range lines {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// Seeding only fills a vacuum: an auto-allow arriving after a policy load
+// must not replace that policy with the deny-default stub.
+func TestAutoAllowSeed_LeavesLoadedConfigAlone(t *testing.T) {
 	cm := NewConfigManager()
 	if err := cm.LoadConfigFromRules([]Rule{
 		{Type: RuleTypeHostname, Value: "github.com", Action: ActionAllow},
@@ -143,27 +229,27 @@ func TestEnsureBaseConfig_LeavesLoadedConfigAlone(t *testing.T) {
 		t.Fatalf("LoadConfigFromRules() error = %v", err)
 	}
 
-	cm.EnsureBaseConfig()
+	cm.EnsureHostnameAllowed("app.codecargo.com", []Port{PortHTTPS}, AutoAddedTypeCodeCargoService)
 
 	if got := cm.GetDefaultAction(); got != ActionAllow {
 		t.Errorf("GetDefaultAction() = %q, want %q (loaded config untouched)", got, ActionAllow)
 	}
 	if !cm.MatchHostnameRule("github.com").HasAllow() {
-		t.Errorf("the loaded rule must survive EnsureBaseConfig")
+		t.Errorf("the loaded rule must survive an auto-allow")
 	}
 }
 
-// A fresh manager has no config at all, so the base config must both exist
-// and be deny-default — the same posture GetDefaultAction reports for nil.
-func TestEnsureBaseConfig_SeedsDenyDefault(t *testing.T) {
+// The seeded config is deny-default — the same posture GetDefaultAction
+// already reports for a nil config, so seeding widens what is allowed before
+// a policy lands, never what is denied.
+func TestAutoAllowSeed_IsDenyDefault(t *testing.T) {
 	cm := NewConfigManager()
-	cm.EnsureBaseConfig()
+	cm.EnsureHostnameAllowed("github.com", []Port{PortHTTPS}, AutoAddedTypeGitHubService)
 
 	if got := cm.GetDefaultAction(); got != ActionDeny {
 		t.Errorf("GetDefaultAction() = %q, want %q", got, ActionDeny)
 	}
-	cm.EnsureHostnameAllowed("github.com", []Port{PortHTTPS}, AutoAddedTypeGitHubService)
-	if !cm.MatchHostnameRule("github.com").HasAllow() {
-		t.Errorf("the seeded config must accept auto-allow rules")
+	if cm.MatchHostnameRule("evil.example.com").Matched() {
+		t.Errorf("seeding must not allow anything but the auto-allows themselves")
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -171,6 +171,11 @@ type Manager struct {
 	trackedHostnames map[string]Action              // Track hostnames we have rules for (hostname -> action)
 	maxCacheSize     int                            // Maximum number of IPs to cache
 
+	// autoAllows is the replay layer: every Ensure*Allowed / AddSearchDomains
+	// call, recorded so a config load re-applies it instead of wiping it.
+	// See autoallow.go.
+	autoAllows []autoAllowEntry
+
 	// auditMode is the run's enforcement posture and lives here — next to
 	// DefaultAction — as the single source of truth both datapaths consult:
 	// the DNS proxy reads it per query, and user space writes it into the
@@ -253,7 +258,16 @@ func (cm *Manager) applyLoadedConfig(cfg *FirewallConfig) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config = cfg
-	return cm.resolveRulesLocked()
+	if err := cm.resolveRulesLocked(); err != nil {
+		return err
+	}
+	// The loaded ruleset replaced cm.config wholesale, taking the
+	// infrastructure auto-allows with it. Re-apply them here — against the
+	// new rules, so a policy deny still vetoes an infra allow — rather than
+	// making every caller re-run the auto-allow helpers after each load
+	// (issue #119, autoallow.go).
+	cm.replayAutoAllowsLocked()
+	return nil
 }
 
 // normalizeRules canonicalises rule values in place so cm.config.Rules and
@@ -1646,10 +1660,30 @@ func (cm *Manager) EnsureInfraAllowed(ips []string, ports []Port, autoAddedType 
 // entry may be a bare IP or a CIDR prefix, v4 or v6 — the loopback pair
 // ("127.0.0.0/8", "::1/128") depends on all four shapes working, so an
 // unparseable entry warns instead of vanishing silently.
+//
+// The call is recorded and re-applied after every subsequent config load
+// (issue #119, autoallow.go).
 func (cm *Manager) ensureAllowed(ips []string, ports []Port, autoAddedType AutoAddedType) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
+	// Recorded before the nil-config guard below: a helper called before any
+	// loader has run still takes effect, replayed by the first load.
+	cm.recordAutoAllowLocked(autoAllowEntry{
+		kind:     autoAllowCIDR,
+		values:   ips,
+		ports:    ports,
+		autoType: autoAddedType,
+	})
+	cm.ensureAllowedLocked(ips, ports, autoAddedType, false)
+}
+
+// ensureAllowedLocked is the lock-held core of ensureAllowed, shared with
+// the replay path. `replay` only picks the log level: the first application
+// is the ops log's record of what the run auto-allowed, while a replay
+// repeats those same rules on every subsequent load and would drown it.
+// Caller must hold cm.mu.Lock.
+func (cm *Manager) ensureAllowedLocked(ips []string, ports []Port, autoAddedType AutoAddedType, replay bool) {
 	if cm.config == nil {
 		return
 	}
@@ -1725,7 +1759,12 @@ func (cm *Manager) ensureAllowed(ips []string, ports []Port, autoAddedType AutoA
 			IPNet:         ipnet,
 		})
 
-		slog.Info("Auto-added allow rule", "cidr", cidr, "ports", ports, "autoAddedType", autoAddedType)
+		if replay {
+			slog.Debug("Re-applied auto-added allow rule after config load",
+				"cidr", cidr, "ports", ports, "autoAddedType", autoAddedType)
+		} else {
+			slog.Info("Auto-added allow rule", "cidr", cidr, "ports", ports, "autoAddedType", autoAddedType)
+		}
 	}
 }
 
@@ -1819,6 +1858,10 @@ func (cm *Manager) cidrCoveredLocked(target *net.IPNet, port *Port) bool {
 // EnsureHostnameAllowed adds an allow rule for a hostname so that it (and
 // its subdomains) are permitted through the firewall. This is used in
 // GitHub Actions mode to auto-allow infrastructure like the Actions service.
+//
+// The call is recorded and re-applied after every subsequent config load
+// (issue #119, autoallow.go), so callers may run before any policy source
+// has been read and need not re-invoke this once one lands.
 func (cm *Manager) EnsureHostnameAllowed(hostname string, ports []Port, autoAddedType AutoAddedType) {
 	// DNS names are case-insensitive — store canonical lowercase so
 	// MatchHostnameRule's case-insensitive lookup finds these entries.
@@ -1827,6 +1870,22 @@ func (cm *Manager) EnsureHostnameAllowed(hostname string, ports []Port, autoAdde
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
+	// Recorded before the nil-config guard below: a helper called before any
+	// loader has run still takes effect, replayed by the first load.
+	cm.recordAutoAllowLocked(autoAllowEntry{
+		kind:     autoAllowHostname,
+		values:   []string{hostname},
+		ports:    ports,
+		autoType: autoAddedType,
+	})
+	cm.ensureHostnameAllowedLocked(hostname, ports, autoAddedType, false)
+}
+
+// ensureHostnameAllowedLocked is the lock-held core of
+// EnsureHostnameAllowed, shared with the replay path. `hostname` is already
+// lower-cased; `replay` only picks the log level (see ensureAllowedLocked).
+// Caller must hold cm.mu.Lock.
+func (cm *Manager) ensureHostnameAllowedLocked(hostname string, ports []Port, autoAddedType AutoAddedType, replay bool) {
 	if cm.config == nil {
 		return
 	}
@@ -1856,7 +1915,12 @@ func (cm *Manager) EnsureHostnameAllowed(hostname string, ports []Port, autoAdde
 		AutoAddedType: autoAddedType,
 	})
 
-	slog.Info("Auto-added infrastructure hostname allow rule", "hostname", hostname, "ports", ports, "autoAddedType", autoAddedType)
+	if replay {
+		slog.Debug("Re-applied auto-added infrastructure hostname allow rule after config load",
+			"hostname", hostname, "ports", ports, "autoAddedType", autoAddedType)
+	} else {
+		slog.Info("Auto-added infrastructure hostname allow rule", "hostname", hostname, "ports", ports, "autoAddedType", autoAddedType)
+	}
 }
 
 // GetAutoAllowedTypeForHostname checks if a hostname matches a hostname-based
@@ -2036,10 +2100,11 @@ func (cm *Manager) HasSearchDomainSuffix(hostname string) bool {
 // flags a programming error worth surfacing without losing the good entries
 // that ride alongside it.
 //
-// Like EnsureDNSAllowed / EnsureInfraAllowed / EnsureHostnameAllowed, this
-// silently no-ops when no config has been loaded. The auto-allow path runs
-// only after a successful config load, so a nil config here means a fallback
-// path skipped earlier — keep behaviors uniform across helpers.
+// Like EnsureDNSAllowed / EnsureInfraAllowed / EnsureHostnameAllowed, the
+// merge itself no-ops when no config has been loaded — but the call is
+// recorded either way and replayed onto the first config that loads, so an
+// auto-allow pass running ahead of the policy fetch still takes effect
+// (issue #119, autoallow.go).
 func (cm *Manager) AddSearchDomains(domains []string, logger *slog.Logger) {
 	// Iterate the caller's slice (not the post-merge normalized form) so the
 	// warning reports the original input that the caller passed. The
@@ -2064,6 +2129,16 @@ func (cm *Manager) AddSearchDomains(domains []string, logger *slog.Logger) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
+	// Recorded before the nil-config guard below: a helper called before any
+	// loader has run still takes effect, replayed by the first load.
+	cm.recordAutoAllowLocked(autoAllowEntry{kind: autoAllowSearchDomain, values: valid})
+	cm.addSearchDomainsLocked(valid)
+}
+
+// addSearchDomainsLocked merges already-validated, already-normalized
+// suffixes into the loaded config, shared with the replay path. Caller must
+// hold cm.mu.Lock.
+func (cm *Manager) addSearchDomainsLocked(valid []string) {
 	if cm.config == nil {
 		return
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -261,11 +261,8 @@ func (cm *Manager) applyLoadedConfig(cfg *FirewallConfig) error {
 	if err := cm.resolveRulesLocked(); err != nil {
 		return err
 	}
-	// The loaded ruleset replaced cm.config wholesale, taking the
-	// infrastructure auto-allows with it. Re-apply them here — against the
-	// new rules, so a policy deny still vetoes an infra allow — rather than
-	// making every caller re-run the auto-allow helpers after each load
-	// (issue #119, autoallow.go).
+	// The load replaced cm.config wholesale, taking the infrastructure
+	// auto-allows with it; the journal puts them back (autoallow.go).
 	cm.replayAutoAllowsLocked()
 	return nil
 }
@@ -1661,14 +1658,12 @@ func (cm *Manager) EnsureInfraAllowed(ips []string, ports []Port, autoAddedType 
 // ("127.0.0.0/8", "::1/128") depends on all four shapes working, so an
 // unparseable entry warns instead of vanishing silently.
 //
-// The call is recorded and re-applied after every subsequent config load
-// (issue #119, autoallow.go).
+// Journalled: re-applied after every subsequent config load (issue #119,
+// autoallow.go).
 func (cm *Manager) ensureAllowed(ips []string, ports []Port, autoAddedType AutoAddedType) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	// Recorded before the nil-config guard below: a helper called before any
-	// loader has run still takes effect, replayed by the first load.
 	cm.recordAutoAllowLocked(autoAllowEntry{
 		kind:     autoAllowCIDR,
 		values:   ips,
@@ -1678,15 +1673,14 @@ func (cm *Manager) ensureAllowed(ips []string, ports []Port, autoAddedType AutoA
 	cm.ensureAllowedLocked(ips, ports, autoAddedType, false)
 }
 
-// ensureAllowedLocked is the lock-held core of ensureAllowed, shared with
-// the replay path. `replay` only picks the log level: the first application
-// is the ops log's record of what the run auto-allowed, while a replay
-// repeats those same rules on every subsequent load and would drown it.
-// Caller must hold cm.mu.Lock.
+// ensureAllowedLocked is the lock-held core of ensureAllowed, shared with the
+// replay path. `replay` suppresses the per-rule announcement below: the ops
+// log records an auto-allow once, when it is installed, and re-announcing
+// the same rules on every load would both drown that record and misdate it.
+// replayAutoAllowsLocked logs one summary line instead. Caller must hold
+// cm.mu.Lock.
 func (cm *Manager) ensureAllowedLocked(ips []string, ports []Port, autoAddedType AutoAddedType, replay bool) {
-	if cm.config == nil {
-		return
-	}
+	cm.seedBaseConfigLocked()
 
 	for _, entry := range ips {
 		if entry == "" {
@@ -1759,10 +1753,7 @@ func (cm *Manager) ensureAllowedLocked(ips []string, ports []Port, autoAddedType
 			IPNet:         ipnet,
 		})
 
-		if replay {
-			slog.Debug("Re-applied auto-added allow rule after config load",
-				"cidr", cidr, "ports", ports, "autoAddedType", autoAddedType)
-		} else {
+		if !replay {
 			slog.Info("Auto-added allow rule", "cidr", cidr, "ports", ports, "autoAddedType", autoAddedType)
 		}
 	}
@@ -1859,9 +1850,8 @@ func (cm *Manager) cidrCoveredLocked(target *net.IPNet, port *Port) bool {
 // its subdomains) are permitted through the firewall. This is used in
 // GitHub Actions mode to auto-allow infrastructure like the Actions service.
 //
-// The call is recorded and re-applied after every subsequent config load
-// (issue #119, autoallow.go), so callers may run before any policy source
-// has been read and need not re-invoke this once one lands.
+// Journalled: callers may run before any policy source has been read, and
+// need not re-invoke this once one lands (issue #119, autoallow.go).
 func (cm *Manager) EnsureHostnameAllowed(hostname string, ports []Port, autoAddedType AutoAddedType) {
 	// DNS names are case-insensitive — store canonical lowercase so
 	// MatchHostnameRule's case-insensitive lookup finds these entries.
@@ -1870,8 +1860,6 @@ func (cm *Manager) EnsureHostnameAllowed(hostname string, ports []Port, autoAdde
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	// Recorded before the nil-config guard below: a helper called before any
-	// loader has run still takes effect, replayed by the first load.
 	cm.recordAutoAllowLocked(autoAllowEntry{
 		kind:     autoAllowHostname,
 		values:   []string{hostname},
@@ -1881,14 +1869,16 @@ func (cm *Manager) EnsureHostnameAllowed(hostname string, ports []Port, autoAdde
 	cm.ensureHostnameAllowedLocked(hostname, ports, autoAddedType, false)
 }
 
-// ensureHostnameAllowedLocked is the lock-held core of
-// EnsureHostnameAllowed, shared with the replay path. `hostname` is already
-// lower-cased; `replay` only picks the log level (see ensureAllowedLocked).
-// Caller must hold cm.mu.Lock.
+// ensureHostnameAllowedLocked is the lock-held core of EnsureHostnameAllowed,
+// shared with the replay path; `hostname` is already lower-cased and `replay`
+// suppresses the announcement (see ensureAllowedLocked). Caller must hold
+// cm.mu.Lock.
+//
+// Unlike the CIDR path this has no deny-veto: a hostname the loaded policy
+// denies is appended as an allow anyway and wins on exact-match-last. That
+// asymmetry predates the journal and is unchanged by it (issue #121).
 func (cm *Manager) ensureHostnameAllowedLocked(hostname string, ports []Port, autoAddedType AutoAddedType, replay bool) {
-	if cm.config == nil {
-		return
-	}
+	cm.seedBaseConfigLocked()
 
 	// Skip if already tracked as allowed
 	if action, ok := cm.trackedHostnames[hostname]; ok && action == ActionAllow {
@@ -1915,10 +1905,7 @@ func (cm *Manager) ensureHostnameAllowedLocked(hostname string, ports []Port, au
 		AutoAddedType: autoAddedType,
 	})
 
-	if replay {
-		slog.Debug("Re-applied auto-added infrastructure hostname allow rule after config load",
-			"hostname", hostname, "ports", ports, "autoAddedType", autoAddedType)
-	} else {
+	if !replay {
 		slog.Info("Auto-added infrastructure hostname allow rule", "hostname", hostname, "ports", ports, "autoAddedType", autoAddedType)
 	}
 }
@@ -2100,10 +2087,9 @@ func (cm *Manager) HasSearchDomainSuffix(hostname string) bool {
 // flags a programming error worth surfacing without losing the good entries
 // that ride alongside it.
 //
-// Like EnsureDNSAllowed / EnsureInfraAllowed / EnsureHostnameAllowed, the
-// merge itself no-ops when no config has been loaded — but the call is
-// recorded either way and replayed onto the first config that loads, so an
-// auto-allow pass running ahead of the policy fetch still takes effect
+// Like EnsureDNSAllowed / EnsureInfraAllowed / EnsureHostnameAllowed, this
+// may run before any policy source has been read: it seeds a deny-default
+// config when none is loaded, and is journalled so later loads re-apply it
 // (issue #119, autoallow.go).
 func (cm *Manager) AddSearchDomains(domains []string, logger *slog.Logger) {
 	// Iterate the caller's slice (not the post-merge normalized form) so the
@@ -2129,19 +2115,15 @@ func (cm *Manager) AddSearchDomains(domains []string, logger *slog.Logger) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	// Recorded before the nil-config guard below: a helper called before any
-	// loader has run still takes effect, replayed by the first load.
 	cm.recordAutoAllowLocked(autoAllowEntry{kind: autoAllowSearchDomain, values: valid})
 	cm.addSearchDomainsLocked(valid)
 }
 
 // addSearchDomainsLocked merges already-validated, already-normalized
-// suffixes into the loaded config, shared with the replay path. Caller must
-// hold cm.mu.Lock.
+// suffixes into the config, shared with the replay path. Caller must hold
+// cm.mu.Lock.
 func (cm *Manager) addSearchDomainsLocked(valid []string) {
-	if cm.config == nil {
-		return
-	}
+	cm.seedBaseConfigLocked()
 	cm.config.SearchDomains = mergeNormalizedSearchDomains(cm.config.SearchDomains, valid)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1924,21 +1924,19 @@ func TestAddSearchDomains_KeepsValidSkipsInvalid(t *testing.T) {
 	}
 }
 
-// AddSearchDomains must no-op on a nil config, matching the behavior of the
-// other auto-allow helpers (EnsureDNSAllowed / EnsureInfraAllowed /
-// EnsureHostnameAllowed). Otherwise the no-config fallback path would
-// partially succeed with only the search-domain set populated.
-func TestAddSearchDomains_NoConfigIsNoOp(t *testing.T) {
+// AddSearchDomains on a fresh manager seeds a deny-default config and
+// installs, so an auto-allow pass running before the policy fetch takes
+// effect (issue #119). It used to no-op, which is why the pass had to run
+// after the load.
+func TestAddSearchDomains_SeedsConfigWhenNoneLoaded(t *testing.T) {
 	cm := NewConfigManager()
-	// cm.config is intentionally nil — simulate the fallback path where
-	// LoadConfig / LoadFromEnv / LoadConfigFromCargoWall all failed.
 	cm.AddSearchDomains([]string{".compute.internal"}, slog.Default())
 
-	if got := cm.GetSearchDomains(); got != nil {
-		t.Errorf("GetSearchDomains() = %v, want nil (no-op on nil config)", got)
+	if got := cm.GetSearchDomains(); len(got) != 1 || got[0] != ".compute.internal" {
+		t.Errorf("GetSearchDomains() = %v, want [.compute.internal]", got)
 	}
-	if cm.config != nil {
-		t.Errorf("cm.config should remain nil; got %+v", cm.config)
+	if !cm.HasSearchDomainSuffix("bastion.compute.internal") {
+		t.Errorf("HasSearchDomainSuffix() = false, want true on the seeded config")
 	}
 }
 
@@ -4092,28 +4090,35 @@ func TestNilConfigSafety(t *testing.T) {
 				t.Errorf("GetAutoAllowedType() = %q, want None", got)
 			}
 		}},
-		{"EnsureHostnameAllowed no-ops", func(t *testing.T, cm *Manager) {
+		// The Ensure* helpers no longer no-op on a nil config: they seed a
+		// deny-default one and install, so an auto-allow pass can run before
+		// any policy source has been read (issue #119). Still listed here —
+		// a fresh manager is exactly where that seeding must not panic.
+		{"EnsureHostnameAllowed seeds and installs", func(t *testing.T, cm *Manager) {
 			cm.EnsureHostnameAllowed("github.com", []Port{PortHTTPS}, AutoAddedTypeGitHubService)
-			if len(cm.GetResolvedRules()) != 0 {
-				t.Errorf("expected no rule added on nil config, got %d", len(cm.GetResolvedRules()))
+			if !cm.MatchHostnameRule("github.com").HasAllow() {
+				t.Errorf("expected the rule to land on the seeded config, got %+v", cm.GetResolvedRules())
+			}
+			if got := cm.GetDefaultAction(); got != ActionDeny {
+				t.Errorf("seeded default action = %q, want %q", got, ActionDeny)
 			}
 		}},
-		{"EnsureDNSAllowed no-ops", func(t *testing.T, cm *Manager) {
+		{"EnsureDNSAllowed seeds and installs", func(t *testing.T, cm *Manager) {
 			cm.EnsureDNSAllowed([]string{"8.8.8.8"})
-			if len(cm.GetResolvedRules()) != 0 {
-				t.Errorf("expected no rule added on nil config, got %d", len(cm.GetResolvedRules()))
+			if len(cm.GetResolvedRules()) != 1 {
+				t.Errorf("expected 1 rule on the seeded config, got %d", len(cm.GetResolvedRules()))
 			}
 		}},
-		{"EnsureInfraAllowed no-ops", func(t *testing.T, cm *Manager) {
+		{"EnsureInfraAllowed seeds and installs", func(t *testing.T, cm *Manager) {
 			cm.EnsureInfraAllowed([]string{"169.254.169.254"}, []Port{PortHTTP}, AutoAddedTypeCloudMetadata)
-			if len(cm.GetResolvedRules()) != 0 {
-				t.Errorf("expected no rule added on nil config, got %d", len(cm.GetResolvedRules()))
+			if len(cm.GetResolvedRules()) != 1 {
+				t.Errorf("expected 1 rule on the seeded config, got %d", len(cm.GetResolvedRules()))
 			}
 		}},
-		{"AddSearchDomains no-ops", func(t *testing.T, cm *Manager) {
+		{"AddSearchDomains seeds and installs", func(t *testing.T, cm *Manager) {
 			cm.AddSearchDomains([]string{".compute.internal"}, slog.Default())
-			if got := cm.GetSearchDomains(); got != nil {
-				t.Errorf("expected no search domains added on nil config, got %v", got)
+			if got := cm.GetSearchDomains(); len(got) != 1 || got[0] != ".compute.internal" {
+				t.Errorf("GetSearchDomains() = %v, want [.compute.internal]", got)
 			}
 		}},
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1653,12 +1653,11 @@ func TestConsecutiveDoubleStarRejected(t *testing.T) {
 
 // Mirrors the GitHub Actions startup flow: the SaaS API hostname is added to
 // an empty bootstrap config so the policy fetch can resolve, then
-// LoadConfigFromCargoWall replaces the ruleset with the fetched policy (which
-// does not contain the API hostname), then autoAllowInfraHosts re-adds it.
-// Before the fix, the third step's EnsureHostnameAllowed call no-op'd on a
-// stale trackedHostnames entry, leaving the hostname unmatched at DNS-filter
-// time.
-func TestEnsureHostnameAllowed_ReAddedAfterCargoWallReload(t *testing.T) {
+// LoadConfigFromCargoWall replaces the ruleset with the fetched policy, which
+// does not contain the API hostname. The replay layer re-applies it (issue
+// #119); a re-add afterwards must still be idempotent rather than no-op on a
+// stale trackedHostnames entry or stack a duplicate rule.
+func TestEnsureHostnameAllowed_SurvivesCargoWallReload(t *testing.T) {
 	cm := NewConfigManager()
 
 	// Bootstrap with an empty deny-all config and add the API hostname.
@@ -1689,14 +1688,21 @@ func TestEnsureHostnameAllowed_ReAddedAfterCargoWallReload(t *testing.T) {
 		t.Fatalf("LoadConfigFromCargoWall() error = %v", err)
 	}
 
-	// After the reload, the API hostname is no longer in the ruleset.
-	if v := cm.MatchHostnameRule("app.codecargo.com"); v.Matched() {
-		t.Fatalf("after reload, MatchHostnameRule(app.codecargo.com) = %+v, want empty", v)
+	// The reload replaces cm.config wholesale, but the auto-allow replay
+	// layer re-applies the API hostname onto the new ruleset (issue #119) —
+	// the fetch that policy came from must keep working, and so must the DNS
+	// proxy's gate for it.
+	if v := cm.MatchHostnameRule("app.codecargo.com"); !v.HasAllow() {
+		t.Fatalf("after reload, MatchHostnameRule(app.codecargo.com) = %+v, want allow", v)
 	}
 
-	// autoAllowInfraHosts re-adds the API hostname. This must actually install
-	// a rule, not no-op on a stale trackedHostnames entry from the bootstrap.
+	// Re-adding is still idempotent: call sites that predate the replay layer
+	// name the hostname again after the load, and that must neither no-op on
+	// a stale trackedHostnames entry nor stack a duplicate rule.
 	cm.EnsureHostnameAllowed("app.codecargo.com", []Port{PortHTTPS}, AutoAddedTypeCodeCargoService)
+	if got := countRules(cm, AutoAddedTypeCodeCargoService); got != 1 {
+		t.Errorf("codecargo_service rules after re-add = %d, want 1", got)
+	}
 	v := cm.MatchHostnameRule("app.codecargo.com")
 	if !v.HasAllow() {
 		t.Errorf("after re-add, MatchHostnameRule(app.codecargo.com) verdict = %+v, want allow", v)

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1187,7 +1187,6 @@ func TestIsQueryAllowed_InfraAutoAllowsSpanThePolicyFetch(t *testing.T) {
 	const domain = "productionresultssa16.blob.core.windows.net"
 
 	cfg := config.NewConfigManager()
-	cfg.EnsureBaseConfig()
 	cfg.EnsureHostnameAllowed("blob.core.windows.net",
 		[]config.Port{config.PortHTTPS}, config.AutoAddedTypeAzureInfrastructure)
 

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -1177,6 +1177,38 @@ func TestIsQueryAllowed(t *testing.T) {
 	}
 }
 
+// The query gate must already know the infrastructure auto-allows when the
+// proxy arms filtering, and must keep knowing them once the fetched policy
+// replaces the ruleset. Before issue #119 the auto-allow pass ran behind the
+// policy fetch, so a hostname like productionresultssa16.blob.core.windows.net
+// — allowed only by the Azure infrastructure auto-allow — was REFUSED for the
+// length of that fetch, and the load itself would have wiped an earlier pass.
+func TestIsQueryAllowed_InfraAutoAllowsSpanThePolicyFetch(t *testing.T) {
+	const domain = "productionresultssa16.blob.core.windows.net"
+
+	cfg := config.NewConfigManager()
+	cfg.EnsureBaseConfig()
+	cfg.EnsureHostnameAllowed("blob.core.windows.net",
+		[]config.Port{config.PortHTTPS}, config.AutoAddedTypeAzureInfrastructure)
+
+	server := &Server{
+		config:        cfg,
+		filterQueries: true,
+		logger:        slog.Default(),
+	}
+	assert.True(t, server.isQueryAllowed(domain, dns.TypeA),
+		"infra hostname must be allowed before any policy has loaded")
+
+	// The fetched policy names neither the hostname nor its CNAME target —
+	// exactly the policy from the run in issue #119.
+	require.NoError(t, cfg.LoadConfigFromRules([]config.Rule{
+		{Type: config.RuleTypeHostname, Value: "*.*.store.core.windows.net", Action: config.ActionAllow},
+	}, config.ActionDeny))
+
+	assert.True(t, server.isQueryAllowed(domain, dns.TypeA),
+		"infra hostname must survive the policy load that replaces the ruleset")
+}
+
 func TestIsQueryAllowed_SearchDomainBypass(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/scripts/ci/gitlab-ci.sh
+++ b/scripts/ci/gitlab-ci.sh
@@ -164,6 +164,33 @@ verify_cloud_detect() {
   echo "✅ Cloud provider detection ran: $DETECTED"
 }
 
+# Issue #119: the infrastructure auto-allows must be installed BEFORE the DNS
+# proxy arms query filtering. When they landed after — behind the policy fetch
+# — every infrastructure hostname queried inside that window was REFUSED under
+# the pre-policy default-deny. One process writing one stream, so line order
+# is decision order.
+verify_startup_order() {
+  LOG=/tmp/cargowall.log
+  FILTER_LINE=$(sudo grep -n "DNS query filtering enabled" "$LOG" | head -1 | cut -d: -f1) || true
+  INFRA_LINE=$(sudo grep -n "Auto-added infrastructure hostname allow rule" "$LOG" | tail -1 | cut -d: -f1) || true
+
+  if [ -z "${FILTER_LINE:-}" ]; then
+    echo "❌ 'DNS query filtering enabled' missing — the --gitlab-ci preset arms it"
+    exit 1
+  fi
+  if [ -z "${INFRA_LINE:-}" ]; then
+    echo "❌ no infrastructure hostname auto-allows logged — the auto-allow pass never ran"
+    sudo grep -i "auto-a" "$LOG" || true
+    exit 1
+  fi
+  if [ "$INFRA_LINE" -gt "$FILTER_LINE" ]; then
+    echo "❌ auto-allow ran AFTER query filtering armed (line $INFRA_LINE > $FILTER_LINE) — #119 regression"
+    sudo grep -nE "Auto-added infrastructure hostname allow rule|DNS query filtering enabled" "$LOG" || true
+    exit 1
+  fi
+  echo "✅ infrastructure auto-allows installed before query filtering armed (line $INFRA_LINE < $FILTER_LINE)"
+}
+
 verify_audit() {
   AUDIT_LOG=/tmp/cargowall-audit.json
   if ! sudo test -s "$AUDIT_LOG"; then
@@ -211,6 +238,7 @@ case "${1:-}" in
   dns-control) dns_control ;;
   verify-dns-verdicts) verify_dns_verdicts ;;
   verify-cloud-detect) verify_cloud_detect ;;
+  verify-startup-order) verify_startup_order ;;
   verify-audit) verify_audit ;;
   stop) stop ;;
   verify-pidfile-removed) verify_pidfile_removed ;;

--- a/scripts/ci/gitlab-ci.sh
+++ b/scripts/ci/gitlab-ci.sh
@@ -169,10 +169,15 @@ verify_cloud_detect() {
 # — every infrastructure hostname queried inside that window was REFUSED under
 # the pre-policy default-deny. One process writing one stream, so line order
 # is decision order.
+#
+# Both patterns anchor at the JSON logger's "msg" field (this job runs the
+# default JSON handler; --github-action swaps in the Actions handler). A bare
+# substring match would widen to any future line that merely quotes the
+# message — a replay or reconciliation log, say.
 verify_startup_order() {
   LOG=/tmp/cargowall.log
-  FILTER_LINE=$(sudo grep -n "DNS query filtering enabled" "$LOG" | head -1 | cut -d: -f1) || true
-  INFRA_LINE=$(sudo grep -n "Auto-added infrastructure hostname allow rule" "$LOG" | tail -1 | cut -d: -f1) || true
+  FILTER_LINE=$(sudo grep -n '"msg":"DNS query filtering enabled' "$LOG" | head -1 | cut -d: -f1) || true
+  INFRA_LINE=$(sudo grep -n '"msg":"Auto-added infrastructure hostname allow rule"' "$LOG" | tail -1 | cut -d: -f1) || true
 
   if [ -z "${FILTER_LINE:-}" ]; then
     echo "❌ 'DNS query filtering enabled' missing — the --gitlab-ci preset arms it"
@@ -185,7 +190,7 @@ verify_startup_order() {
   fi
   if [ "$INFRA_LINE" -gt "$FILTER_LINE" ]; then
     echo "❌ auto-allow ran AFTER query filtering armed (line $INFRA_LINE > $FILTER_LINE) — #119 regression"
-    sudo grep -nE "Auto-added infrastructure hostname allow rule|DNS query filtering enabled" "$LOG" || true
+    sudo grep -nE '"msg":"(Auto-added infrastructure hostname allow rule|DNS query filtering enabled)' "$LOG" || true
     exit 1
   fi
   echo "✅ infrastructure auto-allows installed before query filtering armed (line $INFRA_LINE < $FILTER_LINE)"


### PR DESCRIPTION
Closes #119 (first half — see **Scope** below).

DNS query filtering is armed the moment the proxy starts listening, but the infrastructure auto-allows were installed ~730ms later, behind the policy fetch. Every query in that window that only an auto-allow rule would have covered was REFUSED under the pre-policy default-deny. Observed on a `build-prod` run (Azure-hosted runner, enforce mode): six `dns_blocked` events for `productionresultssa16.blob.core.windows.net`, a name allowed **only** by the Azure infrastructure auto-allow — the fetched policy carries `*.*.store.core.windows.net` (its CNAME target) and `blob.storage.azure.net`, neither of which helps, because the query gate matches the name the client asked for.

```
17:56:18.542  DNS query filtering enabled (blocks DNS tunneling)
17:56:18.552  DNS query blocked domain=productionresultssa16.blob.core.windows.net   ← x4
17:56:18.726  Resolving rules count=0
17:56:19.068  Raw policy from API ...                                                ← 342ms round trip
17:56:19.269  Auto-added infrastructure hostname allow rule hostname=blob.core.windows.net
17:56:19.310  Learned CNAME target ... source=rule:blob.core.windows.net             ← 40ms later, fine
```

The ordering was not gratuitous: `applyLoadedConfig` replaces `cm.config` and rebuilds `resolvedRules` wholesale, so anything installed before a load is wiped by it. The same log proves it — `loadCIConfig` adds `app.codecargo.com` at 18.726 so the fetch itself can resolve, the policy load discards it, and `autoAllowCodeCargoAPI` re-adds it at 19.269. Running the auto-allow pass last was the only way it could stick.

## Change

- **`pkg/config/autoallow.go`** (new): the auto-allow journal. Every `Ensure*Allowed` / `AddSearchDomains` call records its **input** — not the rule it produced — and `applyLoadedConfig` replays the journal after `resolveRulesLocked`. Replaying the input rather than the rule is what makes the outcome identical to the old auto-allow-runs-last ordering: the locked cores re-run their dedup and (on the CIDR path) deny-veto checks against the newly loaded ruleset. `seedBaseConfigLocked` gives an auto-allow somewhere to land when no loader has run yet; deny-default is already what `GetDefaultAction` reports for a nil config, so seeding widens what is *allowed* before a policy arrives, never what is denied.
- **`pkg/config/config.go`**: the three helpers split into a recording wrapper plus a lock-held core shared with replay, and the cores seed instead of no-oping on a nil config. Replay is **silent** — an auto-allow is announced in the ops log once, where it is installed; re-announcing on every load would misdate the install and make a replay indistinguishable from a late install to the CI gate below. `replayAutoAllowsLocked` emits one summary line for the pass.
- **`cmd/start.go`**: `applyAutoAllowHelpers` → `populateAutoAllowRules`, called before `dns.NewServer`/`EnableQueryFiltering` instead of 400 lines later. It loses the firewall parameter and the `ran` bookkeeping — with the rules present before the policy load, the unconditional `fw.UpdateAllowlistTC` at `cmd/start.go:673` already programs them. The `LoadConfigFromRules(nil, deny)` bootstrap in `loadCIConfig` is deleted outright: the API-hostname `EnsureHostnameAllowed` seeds, so lockdown keeps its "CI infrastructure auto-allows remain active" posture without a wipe+replay over a live ruleset.
- **`scripts/ci/gitlab-ci.sh` + `ci.yml`**: a `verify-startup-order` gate asserting the last install announcement precedes `DNS query filtering enabled`. Both patterns anchor at the JSON logger's `"msg"` field rather than matching a substring, so no future line that merely quotes the message can satisfy or break it.

### What the journal does and does not preserve

A CIDR auto-allow is still vetoed by a loaded deny that covers it (`cidrDenyCoversLocked`). A hostname auto-allow is **not**: `ensureHostnameAllowedLocked` dedups only against an existing allow, so an allow for a name the policy denies is appended anyway and wins on exact-match-last. That asymmetry predates this PR — the pass used to run after the load and appended the same rule to the same slice — and `TestAutoAllowReplay_HostnamePrecedenceUnchangedByOrdering` pins that both orderings produce the identical verdict. Whether the hostname case is right at all is #121.

### Log-reading note for reviewers

Two of the six refusals in that run are timestamped `19.304`/`19.305` — *after* the rule at `19.269` — which reads like a rule-visibility race. It isn't. `handleDNSQuery` computes the verdict, then runs `attributeClient` (a cold `sock_diag` dump plus BPF map lookups and `readComm`), then logs; the timestamp is post-attribution and the decisions were made before `19.269`. The four earlier refusals carry no attribution fields at all — step attribution wasn't installed until `19.222` — which is why they show no lag.

## Verified

- Live run in the Lima VM, the `gitlab-ci` job in miniature (`--gitlab-ci --audit-mode --debug`, real eBPF + iptables + Docker): the two hostname installs land at log lines 6–7, `DNS query filtering enabled` at line 8, gate green. Clean teardown, no leftover DNAT rules.
- The gate was exercised against crafted logs in both failure directions: reversed order fails, and a log containing only replay output fails with "the auto-allow pass never ran" — so it cannot be satisfied by a replay line.
- New tests in `pkg/config/autoallow_test.go`: survives a load, a loaded deny still vetoes a CIDR auto-allow, matchable on a fresh manager, dedup of repeated calls, hostname precedence unchanged by ordering, replay does not re-announce (the property the CI gate rests on, caught by `go test` rather than only by the gitlab-ci job), and seeding neither clobbers a loaded config nor softens the default action.
- A `pkg/dns` test pins the invariant at the real seam: `isQueryAllowed("productionresultssa16.blob.core.windows.net")` is true both before and after a policy load naming only `*.*.store.core.windows.net`.
- `TestEnsureHostnameAllowed_ReAddedAfterCargoWallReload` is renamed `..._SurvivesCargoWallReload` and inverted: it asserted the wipe this PR removes. The idempotent-re-add half is kept, plus a no-duplicate-rule assertion. `TestNilConfigSafety`'s four `Ensure*` subtests now assert seed-and-install; the panic-safety point they exist for is unchanged.
- Full suite green; `-race` green on `pkg/config`, `pkg/dns`, `cmd`; staticcheck, gofumpt and goimports-reviser clean; root BPF tests pass except the two known VM-kernel EINVALs (`TestTcEgress/Truncated_IP{,v6}_header`, pre-existing on clean main — GitHub CI is the authority there).

## Scope

#119 also proposes a query-side late-allow reconciliation: a `dns_blocked` record for a name a rule covered 40ms later stays in the audit log and is pushed to the SaaS as a block, with no equivalent of #83's `connection_late_allowed`. That half is deliberately not here — it edits `ApplyRulesToTrackedHostnames`, the event-type const block and the summary classification, all of which #118 also rewrites. It is implemented on `matt/sni` instead, so this PR stays a small ordering fix.
